### PR TITLE
Fix circleci pip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Opacus also uses [isort](https://github.com/timothycrosley/isort) to sort import
 alphabetically and separate into sections. isort is installed easily via
 pip using `pip install isort`, and run locally by calling
 ```bash
-isort
+isort -v -l 88 -o opacus --lines-after-imports 2 -m 3 --trailing-comma  .
 ```
 from the repository root. Configuration for isort is located in .isort.cfg.
 

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -40,7 +40,7 @@ export TERM=xterm
 pip install --upgrade pip
 
 # install with dev dependencies
-pip install -e .[dev]
+pip install -e .[dev] --user
 
 # install pytorch nightly if asked for
 if [[ $PYTORCH_NIGHTLY == true ]]; then


### PR DESCRIPTION
Summary:
CircleCI Checks Test Failure in integrationtest_py37_torch_release_cuda -> install dependencies via pip

+ Update doc for isort

Differential Revision: D31856875

