### PR TITLE
make  module validator compatible with torch 1.8

### DIFF
--- a/opacus/tests/module_validator_test.py
+++ b/opacus/tests/module_validator_test.py
@@ -62,7 +62,12 @@ class ModuleValidator_test(unittest.TestCase):
             self.assertGreater(len(log_cm.records), 0)
             for log_record in log_cm.records:
                 log_msg = log_record.getMessage()
-                self.assertRegex(log_msg, "Replaced sub_module .+ with .*")
+                self.assertRegex(
+                    log_msg,
+                    "Replaced sub_module .+ with .*"
+                    "|"
+                    "The default batch_norm fixer replaces BatchNorm with GroupNorm",
+                )
 
         # with self.assertNoLogs(level="INFO"):
         #     ModuleValidator.fix(self.fixed_model)

--- a/opacus/utils/module_utils.py
+++ b/opacus/utils/module_utils.py
@@ -76,6 +76,33 @@ def clone_module(module: nn.Module) -> nn.Module:
     return module_copy
 
 
+def get_submodule(module: nn.Module, target: str) -> nn.Module:
+    """
+    Returns the submodule given by target if it exists, otherwise throws an error.
+
+    This is copy-pasta of Pytorch 1.9's ``get_submodule()`` implementation; and is
+    included here to also support Pytorch 1.8. This function can be removed in favour
+    of ``module.get_submodule()`` once Opacus abandons support for torch 1.8.
+
+    See more details at https://pytorch.org/docs/stable/generated/torch.nn.Module.html?highlight=get_submodule#torch.nn.Module.get_submodule
+    """
+    if target == "":
+        return module
+
+    atoms: List[str] = target.split(".")
+    mod: nn.Module = module
+
+    for item in atoms:
+        if not hasattr(mod, item):
+            raise AttributeError(
+                mod._get_name() + " has no " "attribute `" + item + "`"
+            )
+        mod = getattr(mod, item)
+        if not isinstance(mod, torch.nn.Module):
+            raise AttributeError("`" + item + "` is not " "an nn.Module")
+    return mod
+
+
 def are_state_dict_equal(sd1: OrderedDict, sd2: OrderedDict):
     if len(sd1) != len(sd2):
         logger.error(f"Length mismatch: {len(sd1)} vs {len(sd2)}")

--- a/opacus/validators/batch_norm.py
+++ b/opacus/validators/batch_norm.py
@@ -48,10 +48,10 @@ def validate(module: BATCHNORM) -> None:
     [nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d, nn.SyncBatchNorm]
 )
 def fix(module: BATCHNORM) -> nn.GroupNorm:
-    logger.info("The default fixer replaces BatchNorm with GroupNorm."
-    " The batch_norm validator module also offeers implementations to replace"
+    logger.info("The default batch_norm fixer replaces BatchNorm with GroupNorm."
+    " The batch_norm validator module also offers implementations to replace"
     " it with InstanceNorm or Identity. Please check them out and override the"
-    " fixer incase those are more suitable for your needs.")
+    " fixer if those are more suitable for your needs.")
     return _batchnorm_to_groupnorm(module)
 
 

--- a/opacus/validators/module_validator.py
+++ b/opacus/validators/module_validator.py
@@ -7,7 +7,7 @@ from typing import List
 
 import torch.nn as nn
 from opacus.grad_sample.grad_sample_module import GradSampleModule
-from opacus.utils.module_utils import clone_module
+from opacus.utils.module_utils import clone_module, get_submodule
 from opacus.validators.errors import (
     IllegalModuleConfigurationError,
     UnsupportedModuleError,
@@ -97,7 +97,7 @@ class ModuleValidator:
         sub_module_names = [name for name, _ in module.named_modules()]
         for sub_module_name in sub_module_names:
             # get sub_module
-            sub_module = module.get_submodule(sub_module_name)
+            sub_module = get_submodule(module, sub_module_name)
             # if sub_module has a registered fixer
             if type(sub_module) in ModuleValidator.FIXERS:
                 # get a repalcement for sub_module


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

The module validator introduced in #227 was not compatible with torch 1.8 as it used `nn.Module`'s `get_submodule()` method, which was introduced in torch 1.9.
In this PR, I have copy-pasted that implementation into util function to make Opacus compatible with torch 1.8.

Also made some minor changes to the unit tests to work with the changes introduced in the last commit of #227 

## How Has This Been Tested (if it applies)

Tested that unit tests pass on torch 1.8

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
