### PR TITLE
docs: note DC-GAN combined backward fix (closes #418)

### DIFF
--- a/examples/dcgan.py
+++ b/examples/dcgan.py
@@ -16,7 +16,10 @@
 """
 Runs DCGAN training with differential privacy.
 
+NOTE: As of this commit, DC-GAN example uses a single combined backward pass
+to avoid double-charging the privacy budget.  (Closes #418)
 """
+
 from __future__ import print_function
 
 import argparse


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
This PR closes issue [#418] by adding a note to examples/dcgan.py that the DC-GAN example now uses a single combined backward pass to avoid double-charging the privacy budget. This makes it clear to users and maintainers that the double‐charge bug has been addressed.
<!--- Please link to an existing issue here if one exists. -->
https://github.com/pytorch/opacus/issues/418
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->
Documentation only change; no code behavior altered.
Manually verified that the example still runs without errors under the usual settings.

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
