### PR TITLE
Fix AdaClipOptimizer

### DIFF
--- a/opacus/optimizers/adaclipoptimizer.py
+++ b/opacus/optimizers/adaclipoptimizer.py
@@ -126,7 +126,7 @@ class AdaClipDPOptimizer(DPOptimizer):
 
         unclipped_num_noise = _generate_noise(
             std=self.unclipped_num_std,
-            reference=self.unclipped_num,
+            reference=self.unclipped_num.float(),
             generator=self.generator,
         )
 


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

AdaClipOptimizer fails on the attempt to [generate noise for `self.unclipped_num`](https://github.com/pytorch/opacus/blob/e1a695c1b82e6749e2ab80b491da9e3d2cfe823b/opacus/optimizers/adaclipoptimizer.py#L127C1-L131C10).
PyTorch fails after the first step complaining that torch.normal is not defined for LongTensors. Converting it to `.float` just before the noise addition seems the shortest change possible to fix the issue. Otherwise, AdaClip doesn't work with the current version of PyTorch:

```python
unclipped_num_noise = _generate_noise(
    std=self.unclipped_num_std,
    reference=self.unclipped_num.float(), <--
    generator=self.generator,
)
```

___
Btw, there is a general issue with how `unclipped_num_std` is handled. Initially it [starts as a ~int~float](https://github.com/pytorch/opacus/blob/e1a695c1b82e6749e2ab80b491da9e3d2cfe823b/opacus/optimizers/adaclipoptimizer.py#L85C9-L85C31):

```python
self.unclipped_num = 0
```

then gets [converted to a tensor almost unintentionally](https://github.com/pytorch/opacus/blob/e1a695c1b82e6749e2ab80b491da9e3d2cfe823b/opacus/optimizers/adaclipoptimizer.py#L108-L110) (most importantly, the tensor is int LongTensor here).

```python
self.unclipped_num += (
    len(per_sample_clip_factor) - (per_sample_clip_factor < 1).sum()
)
```

then the place with the fix where it can [only be a tensor to work as a reference for the `_generate_noise`](https://github.com/pytorch/opacus/blob/42b0e7275c394f08544bcc58040a7c2630b28c18/opacus/optimizers/optimizer.py#L106) function:

```python
unclipped_num_noise = _generate_noise(
    std=self.unclipped_num_std,
    reference=self.unclipped_num,
    generator=self.generator,
)
```

Immediately it is [converted back into a vanilla float](https://github.com/pytorch/opacus/blob/e1a695c1b82e6749e2ab80b491da9e3d2cfe823b/opacus/optimizers/adaclipoptimizer.py#L133C1-L134C50):

```python
self.unclipped_num = float(self.unclipped_num)
```

On your permission I can attend to it deeper and stabilize its type to float. For the sake of generality it can either made to work with `unclipped_num_std=0.0` (although it violates privacy guarantees) or a check with a better exception can be added instead of a cryptic internal pytorch failure.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
