### PR TITLE
Add support for passing args and kwargs to per-sample loss functions

### DIFF
--- a/opacus/utils/adaptive_clipping/adaptive_clipping_utils.py
+++ b/opacus/utils/adaptive_clipping/adaptive_clipping_utils.py
@@ -207,14 +207,13 @@ class DPLossFastGradientAdaptiveClipping(DPLossFastGradientClipping):
         self.clipbound_learning_rate = clipbound_learning_rate
         self.initial_noise_multiplier = initial_noise_multiplier
 
-    def __call__(self, input, target, **kwargs) -> DPTensorFastGradientAdaptiveClipping:
+    def __call__(self, *args, **kwargs) -> DPTensorFastGradientAdaptiveClipping:
         """
         Redefining the forward function to compute per-sample loss and wrap it in DPTensorFastGradientAdaptiveClipping
         """
 
         loss_per_sample = self.criterion(
-            input,
-            target,
+            *args,
             **kwargs,
         )
         return DPTensorFastGradientAdaptiveClipping(

--- a/opacus/utils/fast_gradient_clipping_utils.py
+++ b/opacus/utils/fast_gradient_clipping_utils.py
@@ -106,14 +106,12 @@ class DPLossFastGradientClipping:
         self.loss_reduction = loss_reduction
         self.criterion.reduction = "none"
 
-    def __call__(
-        self, input, target, shape=None, **kwargs
-    ) -> DPTensorFastGradientClipping:
+    def __call__(self, *args, shape=None, **kwargs) -> DPTensorFastGradientClipping:
         """
         Redefining the forward function to compute per-sample loss and wrap it in DPTensorFastGradientClipping
         """
 
-        loss_per_sample = self.criterion(input, target, **kwargs)
+        loss_per_sample = self.criterion(*args, **kwargs)
 
         if shape is not None and loss_per_sample.shape[0] == shape[0] * shape[1]:
             # Note that the privacy unit for generative NLP tasks is per sequence.


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
It prevents `TypeError: DPLossFastGradientAdaptiveClipping.__call__() got an unexpected keyword argument 'vocab_size'` error from triggering when assigning `DPLossFastGradientAdaptiveClipping` or `DPLossFastGradientClipping` to the `.loss_function` property of any `PreTrainedModel`.

Every `PreTrainedModel.loss_function()` call expects `vocab_size` amongst it's keyword arguments:
```
# transformers.models.gpt2.modeling_gpt2.py:1099
# Flatten the tokens
loss = self.loss_function(
        logits,
        labels,
        vocab_size=self.config.vocab_size,
        **kwargs,
    )
```
Meanwhile, `DPLossFastGradientAdaptiveClipping.__call__ `and `DPLossFastGradientClipping.__call__` don't have this keyword argument `vocab_size` in their signature. `vocab` size is later needed for tensor flattening:
```
def ForCausalLMLoss(
    logits,
    labels,
    vocab_size: int,
    num_items_in_batch: Optional[torch.Tensor] = None,
    ignore_index: int = -100,
    shift_labels: Optional[torch.Tensor] = None,
    **kwargs,
) -> torch.Tensor:
    # Upcast to float if we need to compute the loss to avoid potential precision issues
    logits = logits.float()

    if shift_labels is None:
        # Shift so that tokens < n predict n
        labels = nn.functional.pad(labels, (0, 1), value=ignore_index)
        shift_labels = labels[..., 1:].contiguous()

    # Flatten the tokens
    logits = logits.view(-1, vocab_size) <------ used here
```
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)
Tested and trained on transformers' `GPT2LMHeadModel` with LoRA and 4B parameter Llama `LlamaForCausalLM` model, purposefully targeting different model architectures.
<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [ ] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
