### PR TITLE
Added upload of opacus to gcloud in cicd

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,11 +6,14 @@ name: Upload Opacus Python Package to PyPI
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
     - uses: actions/checkout@v2
@@ -29,4 +32,22 @@ jobs:
       run: |
         rm -rf dist/
         python setup.py sdist bdist_wheel
+        twine upload dist/*
+
+    - name: Authenticate to Google Cloud
+      id: auth
+      uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
+      with:
+        workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}
+        token_format: access_token
+        access_token_lifetime: 3600s
+
+    - name: Publish Python package to GCLOUD
+      shell: bash
+      env:
+        TWINE_USERNAME: "oauth2accesstoken"
+        TWINE_PASSWORD: ${{ steps.auth.outputs.access_token }}
+        TWINE_REPOSITORY_URL: ${{vars.GCLOUD_PYTHON_REGISTRY}}
+      run: |   
         twine upload dist/*


### PR DESCRIPTION
New feature: Upload of opacus wheel to https://europe-west4-python.pkg.dev/jetbrains-ml4se-fed/jbr-fed-python/

Motivation: up-to-date opacus wheel needed for building of dp-training package in federated repository

- [ ] The documentation is up-to-date with the changes I made.
- [ ] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
