### PR TITLE
Update github org location

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -34,7 +34,7 @@ const siteConfig = {
   cname: 'opacus.ai',
 
   // used for publishing and more
-  organizationName: 'pytorch',
+  organizationName: 'meta-pytorch',
   projectName: 'opacus',
 
   // Google analytics
@@ -100,7 +100,7 @@ const siteConfig = {
   docsSideNavCollapsible: true,
 
   // URL for editing docs
-  editUrl: 'https://github.com/pytorch/opacus/tree/main/docs/',
+  editUrl: 'https://github.com/meta-pytorch/opacus/tree/main/docs/',
 
   // Disable logo text so we can just show the logo
   disableHeaderTitle: true,


### PR DESCRIPTION
Summary: We moved the repo into meta-pytorch. While links will redirect, we should get the accurate from the start.

Reviewed By: bigfootjon

Differential Revision: D82763948


