### PR TITLE
Remove Support Ukraine banner from Opacus website

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -34,18 +34,8 @@ class HomeSplash extends React.Component {
     const langPart = `${language ? `${language}/` : ''}`;
     const docUrl = doc => `${baseUrl}${docsPart}${langPart}${doc}`;
 
-    const AnnouncementSupportUkraine = () => (
-      <div className="announcementSupportUkraine">
-        <span class="announcementSupportUkraineTitle"> Support Ukraine 🇺🇦 </span>
-        <a href="https://opensource.fb.com/support-ukraine" target="_blank" rel="noopener">
-          <span>Help Provide Humanitarian Aid to Ukraine.</span>
-        </a>
-      </div>
-    );
-
     const SplashContainer = props => (
       <div className="homeContainer">
-        <AnnouncementSupportUkraine />
         <div className="homeSplashFade">
           <div className="wrapper homeWrapper">{props.children}</div>
         </div>


### PR DESCRIPTION
Summary: Remove the AnnouncementSupportUkraine component and its usage from the Opacus website homepage.

Reviewed By: mattcarrollcode

Differential Revision: D96559638


