### PR TITLE
Replace pytest.mark.skip with unittest.skip in opacus tests

### DIFF
--- a/opacus/data_loader.py
+++ b/opacus/data_loader.py
@@ -11,10 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import copy
 import logging
-from functools import partial
-from typing import Any, List, Optional, Sequence, Tuple, Type, Union
+from typing import Any, List, Mapping, Optional, Sequence, Tuple, Type, Union
 
 import torch
 from opacus.utils.uniform_sampler import (
@@ -29,91 +28,179 @@ from torch.utils.data.dataloader import _collate_fn_t
 logger = logging.getLogger(__name__)
 
 
-def collate(
-    batch: List[torch.Tensor],
-    *,
-    collate_fn: Optional[_collate_fn_t],
-    sample_empty_shapes: Sequence[Tuple],
-    dtypes: Sequence[Union[torch.dtype, Type]],
-):
+class CollateFnWithEmpty:
     """
-    Wraps `collate_fn` to handle empty batches.
+    Collate function wrapper that handles empty batches by preserving batch structure.
 
-    Default `collate_fn` implementations typically can't handle batches of length zero.
-    Since this is a possible case for poisson sampling, we need to wrap the collate
-    method, producing tensors with the correct shape and size (albeit the batch
-    dimension being zero-size)
+    This wrapper is stateful and learns the expected batch structure from the first
+    non-empty batch it processes. When an empty batch is encountered, it generates
+    an empty batch with the same structure (tensors, dicts, lists, or nested combinations)
+    but with zero-length batch dimensions.
+
+    This is particularly useful for Poisson sampling in differential privacy, where
+    batch sizes can vary and occasionally result in empty batches.
 
     Args:
-        batch: List of tensort to be passed to collate_fn implementation
-        collate_fn: Collame method to be wrapped
-        sample_empty_shapes: Sample tensors with the expected shape
-        dtypes: Expected dtypes
+        collator_fn: The original collate function to wrap. If None, returns batch as-is.
+        batch_first: If True, batch dimension is the first dimension (index 0).
+            If False, batch dimension is the second dimension (index 1).
+            Default: True
+        rand_on_empty: If True, returns tensors filled with random values (0 or 1)
+            with batch dimension set to 1 when encountering empty batches.
+            If False, returns tensors with batch dimension set to 0.
+            Default: False
 
-    Returns:
-        Batch tensor(s)
+    Example:
+        >>> collate_fn = CollateFnWithEmpty(default_collate)
+        >>> # First batch: [{"x": tensor([1, 2]), "y": tensor([3, 4])}]
+        >>> # Empty batch: [] -> {"x": tensor([]), "y": tensor([])}
+
+    Note:
+        The first batch processed must be non-empty, as it defines the structure
+        for all subsequent empty batches.
+
+        Only torch.Tensor, dict (Mapping), list, and tuple types are supported.
+        If your collate function returns other types, a TypeError will be raised
+        to preserve DP guarantees (returning non-empty data for empty batches
+        would violate the privacy guarantee).
     """
 
-    if len(batch) > 0:
-        return collate_fn(batch)
-    else:
-        return [
-            torch.zeros(shape, dtype=dtype)
-            for shape, dtype in zip(sample_empty_shapes, dtypes)
-        ]
+    def __init__(
+        self,
+        collator_fn: Optional[_collate_fn_t],
+        batch_first: bool = True,
+        rand_on_empty: bool = False,
+        sample_empty_shapes: Optional[Sequence[Tuple]] = None,
+        dtypes: Optional[Sequence[Union[torch.dtype, Type]]] = None,
+    ) -> None:
+        self.wrapped_collator_fn = collator_fn
+        self.batch_first = batch_first
+        self.rand_on_empty = rand_on_empty
+        self.sample_empty_shapes = sample_empty_shapes
+        self.dtypes = dtypes
+        self.first_batch = None
+
+    def __call__(self, batch: List[Any]) -> Union[torch.Tensor, List, Mapping]:
+        if len(batch) > 0:
+            if not self.wrapped_collator_fn:
+                output = batch
+            else:
+                output = self.wrapped_collator_fn(batch)
+            if self.first_batch is None:
+                self.first_batch = copy.deepcopy(output)
+        else:
+            if self.first_batch is None:
+                if self.sample_empty_shapes is not None and self.dtypes is not None:
+                    logger.warning(
+                        "First batch is empty. We are using a list of zero-valued "
+                        "tensors as a batch. This may cause issues if the model "
+                        "expects a different batch format. To fix, use more data, "
+                        "increase epsilon, or increase sampling rate."
+                    )
+                    return [
+                        torch.zeros(shape, dtype=dtype)
+                        for shape, dtype in zip(self.sample_empty_shapes, self.dtypes)
+                    ]
+                else:
+                    logger.warning(
+                        "First batch is empty. We are using an empty list as a "
+                        "batch. This may cause issues if the model expects a "
+                        "different batch format. To fix, use more data, increase "
+                        "epsilon, or increase sampling rate."
+                    )
+                    return []
+
+            # materialize into empty with the same structure as list/dict
+            output = self._make_empty_batch(self.first_batch)
+
+        return output
+
+    def _make_empty_batch(
+        self, sample: Union[torch.Tensor, Mapping, List, Any]
+    ) -> Union[torch.Tensor, Mapping, List, Any]:
+        if torch.is_tensor(sample):
+            shape = list(sample.shape)
+            # If it's at least 1D, set batch dim to 1; otherwise make a 0-length 1D tensor
+            batch_dim = 0 if self.batch_first else 1
+            shape[batch_dim] = 1 if self.rand_on_empty else 0
+            if self.rand_on_empty:
+                return torch.randint(
+                    0, 2, shape, dtype=sample.dtype, device=sample.device
+                )
+            else:
+                return torch.empty(shape, dtype=sample.dtype, device=sample.device)
+
+        if isinstance(sample, Mapping):
+            return {k: self._make_empty_batch(v) for k, v in sample.items()}
+
+        if isinstance(sample, (list, tuple)):
+            converted = [self._make_empty_batch(v) for v in sample]
+            return type(sample)(converted)
+
+        # Unsupported type - raise error to preserve DP guarantees
+        raise TypeError(
+            f"Unsupported batch type: {type(sample).__name__}. "
+            f"CollateFnWithEmpty only supports batches containing torch.Tensor, "
+            f"dict (Mapping), list, or tuple types. "
+            f"If you need support for a different output type, please open an issue at "
+            f"Opacus or submit a PR."
+        )
 
 
 def wrap_collate_with_empty(
     *,
     collate_fn: Optional[_collate_fn_t],
-    sample_empty_shapes: Sequence[Tuple],
-    dtypes: Sequence[Union[torch.dtype, Type]],
-):
+    batch_first: bool = True,
+    rand_on_empty: bool = False,
+    sample_empty_shapes: Optional[Sequence[Tuple]] = None,
+    dtypes: Optional[Sequence[Union[torch.dtype, Type]]] = None,
+) -> CollateFnWithEmpty:
     """
     Wraps given collate function to handle empty batches.
 
+    This function returns a stateful ``CollateFnWithEmpty`` instance that learns
+    the batch structure from the first non-empty batch and uses this structure
+    to generate properly shaped empty batches when needed.
+
     Args:
-        collate_fn: collate function to wrap
-        sample_empty_shapes: expected shape for a batch of size 0. Input is a sequence -
-            one for each tensor in the dataset
+        collate_fn: collate function to wrap. If None, returns batches as-is.
+        batch_first: Flag to indicate if the input tensor to the corresponding module
+            has the first dimension representing the batch. If set to True, dimensions on
+            input tensor are expected be ``[batch_size, ...]``, otherwise
+            ``[K, batch_size, ...]``
+        rand_on_empty: set ``True`` to return a batch containing random numbers when encountering
+            empty batches rather than tensors with zero-length batch dimensions
 
     Returns:
-        New collate function, which is equivalent to input ``collate_fn`` for non-empty
-        batches and outputs empty tensors with shapes from ``sample_empty_shapes`` if
-        the input batch is of size 0
+        CollateFnWithEmpty: A callable that is equivalent to input ``collate_fn`` for non-empty
+            batches and outputs empty tensors with the same structure when the input batch is empty.
+            The structure is learned from the first non-empty batch.
+
+    Example:
+        >>> from torch.utils.data._utils.collate import default_collate
+        >>> collate = wrap_collate_with_empty(collate_fn=default_collate)
+        >>> # First batch defines structure
+        >>> result = collate([{"x": torch.tensor([1, 2])}])
+        >>> # Empty batch uses learned structure
+        >>> empty = collate([])  # Returns {"x": torch.tensor([])}
     """
 
-    return partial(
-        collate,
-        collate_fn=collate_fn,
+    return CollateFnWithEmpty(
+        collate_fn,
+        batch_first=batch_first,
+        rand_on_empty=rand_on_empty,
         sample_empty_shapes=sample_empty_shapes,
         dtypes=dtypes,
     )
 
 
 def shape_safe(x: Any) -> Tuple:
-    """
-    Exception-safe getter for ``shape`` attribute
-
-    Args:
-        x: any object
-
-    Returns:
-        ``x.shape`` if attribute exists, empty tuple otherwise
-    """
+    """Exception-safe getter for ``shape`` attribute."""
     return getattr(x, "shape", ())
 
 
 def dtype_safe(x: Any) -> Union[torch.dtype, Type]:
-    """
-    Exception-safe getter for ``dtype`` attribute
-
-    Args:
-        x: any object
-
-    Returns:
-        ``x.dtype`` if attribute exists, type of x otherwise
-    """
+    """Exception-safe getter for ``dtype`` attribute."""
     return getattr(x, "dtype", type(x))
 
 
@@ -149,6 +236,8 @@ class DPDataLoader(DataLoader):
         drop_last: bool = False,
         generator=None,
         distributed: bool = False,
+        batch_first: bool = True,
+        rand_on_empty: bool = False,
         **kwargs,
     ):
         """
@@ -170,6 +259,8 @@ class DPDataLoader(DataLoader):
             distributed: set ``True`` if you'll be using DPDataLoader in a DDP environment
                 Selects between ``DistributedUniformWithReplacementSampler`` and
                 ``UniformWithReplacementSampler`` sampler implementations
+            rand_on_empty: set ``True`` to return a batch containing random numbers when encountering
+                empty batches rather than tensors with zero-length batch dimensions
         """
 
         self.sample_rate = sample_rate
@@ -189,6 +280,7 @@ class DPDataLoader(DataLoader):
             )
         sample_empty_shapes = [(0, *shape_safe(x)) for x in dataset[0]]
         dtypes = [dtype_safe(x) for x in dataset[0]]
+
         if collate_fn is None:
             collate_fn = default_collate
 
@@ -202,6 +294,8 @@ class DPDataLoader(DataLoader):
             batch_sampler=batch_sampler,
             collate_fn=wrap_collate_with_empty(
                 collate_fn=collate_fn,
+                batch_first=batch_first,
+                rand_on_empty=rand_on_empty,
                 sample_empty_shapes=sample_empty_shapes,
                 dtypes=dtypes,
             ),
@@ -211,7 +305,13 @@ class DPDataLoader(DataLoader):
 
     @classmethod
     def from_data_loader(
-        cls, data_loader: DataLoader, *, distributed: bool = False, generator=None
+        cls,
+        data_loader: DataLoader,
+        *,
+        distributed: bool = False,
+        generator=None,
+        batch_first: bool = True,
+        rand_on_empty: bool = False,
     ):
         """
         Creates new ``DPDataLoader`` based on passed ``data_loader`` argument.
@@ -221,6 +321,14 @@ class DPDataLoader(DataLoader):
             distributed: set ``True`` if you'll be using DPDataLoader in a DDP environment
             generator: Random number generator used to sample elements. Defaults to
                 generator from the original data loader.
+            batch_first: Flag to indicate if the input tensor to the corresponding module
+                has the first dimension representing the batch. If set to True, dimensions on
+                input tensor are expected be ``[batch_size, ...]``, otherwise
+                ``[K, batch_size, ...]``
+            rand_on_empty: set ``True`` to return a batch containing random numbers when encountering
+                empty batches rather than tensors with zero-length batch dimensions
+
+
 
         Returns:
             New DPDataLoader instance, with all attributes and parameters inherited
@@ -250,6 +358,8 @@ class DPDataLoader(DataLoader):
             prefetch_factor=data_loader.prefetch_factor,
             persistent_workers=data_loader.persistent_workers,
             distributed=distributed,
+            batch_first=batch_first,
+            rand_on_empty=rand_on_empty,
         )
 
 

--- a/opacus/tests/batch_memory_manager_test.py
+++ b/opacus/tests/batch_memory_manager_test.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+import pytest
 import torch
 import torch.nn as nn
 from hypothesis import HealthCheck, given, settings
@@ -115,6 +116,7 @@ class BatchMemoryManagerTest(unittest.TestCase):
                     )
                     weights_before = torch.clone(model._module.fc.weight)
 
+    @pytest.mark.skip("Incompatible with the new empty batch handling")
     @given(
         num_workers=st.integers(0, 4),
         pin_memory=st.booleans(),

--- a/opacus/tests/batch_memory_manager_test.py
+++ b/opacus/tests/batch_memory_manager_test.py
@@ -14,7 +14,6 @@
 
 import unittest
 
-import pytest
 import torch
 import torch.nn as nn
 from hypothesis import HealthCheck, given, settings
@@ -116,7 +115,7 @@ class BatchMemoryManagerTest(unittest.TestCase):
                     )
                     weights_before = torch.clone(model._module.fc.weight)
 
-    @pytest.mark.skip("Incompatible with the new empty batch handling")
+    @unittest.skip("Incompatible with the new empty batch handling")
     @given(
         num_workers=st.integers(0, 4),
         pin_memory=st.booleans(),

--- a/opacus/tests/dpdataloader_test.py
+++ b/opacus/tests/dpdataloader_test.py
@@ -15,8 +15,9 @@
 import unittest
 
 import torch
-from opacus.data_loader import DPDataLoader
+from opacus.data_loader import CollateFnWithEmpty, DPDataLoader, wrap_collate_with_empty
 from torch.utils.data import DataLoader, TensorDataset
+from torch.utils.data._utils.collate import default_collate
 
 
 class DPDataLoaderTest(unittest.TestCase):
@@ -26,25 +27,92 @@ class DPDataLoaderTest(unittest.TestCase):
         self.num_classes = 11
 
     def test_collate_classes(self) -> None:
+        """Test that empty batches are handled correctly with classification data"""
         x = torch.randn(self.data_size, self.dimension)
         y = torch.randint(low=0, high=self.num_classes, size=(self.data_size,))
 
         dataset = TensorDataset(x, y)
-        data_loader = DPDataLoader(dataset, sample_rate=1e-5)
+        # Use seeded generator with low sample rate to produce empty batches deterministically
+        # seed=0, sample_rate=0.1 produces non-empty first batch followed by empty batches
+        generator = torch.Generator().manual_seed(0)
+        data_loader = DPDataLoader(dataset, sample_rate=0.1, generator=generator)
 
-        x_b, y_b = next(iter(data_loader))
-        self.assertEqual(x_b.size(0), 0)
-        self.assertEqual(y_b.size(0), 0)
+        # Process batches - verify structure is preserved
+        first_batch = next(iter(data_loader))
+        x_b, y_b = first_batch
+
+        # First batch must be non-empty (to learn structure)
+        self.assertGreater(x_b.size(0), 0, "First batch must be non-empty")
+        self.assertEqual(len(x_b.shape), 2)
+        self.assertEqual(x_b.shape[1], self.dimension)
+
+        # Process all batches and verify at least one is empty
+        batch_count = 1
+        empty_batch_found = False
+        for batch in data_loader:
+            x_b, y_b = batch
+            batch_size = x_b.size(0)
+
+            # Batch dimension should be 0 or positive
+            self.assertGreaterEqual(batch_size, 0)
+            self.assertGreaterEqual(y_b.size(0), 0)
+
+            if batch_size == 0:
+                empty_batch_found = True
+                # Empty batch should still have correct feature dimension
+                self.assertEqual(x_b.shape[1], self.dimension)
+            else:
+                # Non-empty batch should have correct dimensions
+                self.assertEqual(x_b.shape[1], self.dimension)
+            batch_count += 1
+
+        # Verify we actually tested empty batch handling
+        self.assertTrue(
+            empty_batch_found,
+            "No empty batches produced - test doesn't verify empty batch handling",
+        )
+        self.assertGreater(batch_count, 1)
 
     def test_collate_tensor(self) -> None:
+        """Test that empty batches are handled correctly with single tensor data"""
         x = torch.randn(self.data_size, self.dimension)
 
         dataset = TensorDataset(x)
-        data_loader = DPDataLoader(dataset, sample_rate=1e-5)
+        # Use seeded generator with low sample rate to produce empty batches deterministically
+        # seed=0, sample_rate=0.1 produces non-empty first batch followed by empty batches
+        generator = torch.Generator().manual_seed(0)
+        data_loader = DPDataLoader(dataset, sample_rate=0.1, generator=generator)
+        first_batch = next(iter(data_loader))
+        (s,) = first_batch
 
-        (s,) = next(iter(data_loader))
+        # First batch must be non-empty (to learn structure)
+        self.assertGreater(s.size(0), 0, "First batch must be non-empty")
+        self.assertEqual(s.shape[1], self.dimension)
 
-        self.assertEqual(s.size(0), 0)
+        # Process all batches and verify at least one is empty
+        batch_count = 1
+        empty_batch_found = False
+        for batch in data_loader:
+            (s,) = batch
+            batch_size = s.size(0)
+
+            self.assertGreaterEqual(batch_size, 0)
+
+            if batch_size == 0:
+                empty_batch_found = True
+                # Empty batch should still have correct feature dimension
+                self.assertEqual(s.shape[1], self.dimension)
+            else:
+                # Non-empty batch should have correct dimensions
+                self.assertEqual(s.shape[1], self.dimension)
+            batch_count += 1
+
+        # Verify we actually tested empty batch handling
+        self.assertTrue(
+            empty_batch_found,
+            "No empty batches produced - test doesn't verify empty batch handling",
+        )
+        self.assertGreater(batch_count, 1)
 
     def test_drop_last_true(self) -> None:
         x = torch.randn(self.data_size, self.dimension)
@@ -52,3 +120,327 @@ class DPDataLoaderTest(unittest.TestCase):
         dataset = TensorDataset(x)
         data_loader = DataLoader(dataset, drop_last=True)
         _ = DPDataLoader.from_data_loader(data_loader)
+
+
+class CollateFnWithEmptyTest(unittest.TestCase):
+    """Tests for the CollateFnWithEmpty class"""
+
+    def test_simple_tensor_non_empty(self) -> None:
+        """Test that non-empty batches are handled correctly with simple tensors"""
+        collate_fn = CollateFnWithEmpty(default_collate)
+        batch = [torch.tensor([1, 2]), torch.tensor([3, 4])]
+        result = collate_fn(batch)
+
+        self.assertTrue(torch.is_tensor(result))
+        self.assertEqual(result.shape, (2, 2))
+        self.assertTrue(torch.equal(result, torch.tensor([[1, 2], [3, 4]])))
+
+    def test_simple_tensor_empty_batch(self) -> None:
+        """Test that empty batches generate correct empty tensors"""
+        collate_fn = CollateFnWithEmpty(default_collate)
+
+        # First process a non-empty batch to learn structure
+        batch = [torch.tensor([1, 2]), torch.tensor([3, 4])]
+        _ = collate_fn(batch)
+
+        # Now process empty batch
+        empty_result = collate_fn([])
+
+        self.assertTrue(torch.is_tensor(empty_result))
+        self.assertEqual(empty_result.shape[0], 0)  # Batch dimension should be 0
+        self.assertEqual(empty_result.shape[1], 2)  # Other dimensions preserved
+
+    def test_empty_batch_before_first_returns_zero_tensors(self) -> None:
+        """Test that processing empty batch first returns zero-valued tensors when shapes/dtypes provided"""
+        collate_fn = CollateFnWithEmpty(
+            default_collate,
+            sample_empty_shapes=[(0, 3), (0,)],
+            dtypes=[torch.float32, torch.int64],
+        )
+
+        with self.assertLogs("opacus.data_loader", level="WARNING") as log:
+            result = collate_fn([])
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].shape, (0, 3))
+        self.assertEqual(result[0].dtype, torch.float32)
+        self.assertTrue(torch.equal(result[0], torch.zeros(0, 3, dtype=torch.float32)))
+        self.assertEqual(result[1].shape, (0,))
+        self.assertEqual(result[1].dtype, torch.int64)
+        self.assertTrue(
+            any("First batch is empty" in message for message in log.output)
+        )
+
+    def test_empty_first_batch_without_shapes_returns_empty_list(self) -> None:
+        """Test fallback to empty list when sample_empty_shapes/dtypes not provided"""
+        collate_fn = CollateFnWithEmpty(default_collate)
+
+        with self.assertLogs("opacus.data_loader", level="WARNING") as log:
+            result = collate_fn([])
+
+        self.assertEqual(result, [])
+        self.assertTrue(
+            any("First batch is empty" in message for message in log.output)
+        )
+
+    def test_dict_structure_preserved(self) -> None:
+        """Test that dictionary structures are preserved in empty batches"""
+        collate_fn = CollateFnWithEmpty(default_collate)
+
+        # First batch with dict structure
+        batch = [
+            {"x": torch.tensor([1, 2]), "y": torch.tensor([5])},
+            {"x": torch.tensor([3, 4]), "y": torch.tensor([6])},
+        ]
+        result = collate_fn(batch)
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("x", result)
+        self.assertIn("y", result)
+
+        # Empty batch should preserve dict structure
+        empty_result = collate_fn([])
+
+        self.assertIsInstance(empty_result, dict)
+        self.assertIn("x", empty_result)
+        self.assertIn("y", empty_result)
+        self.assertEqual(empty_result["x"].shape[0], 0)
+        self.assertEqual(empty_result["y"].shape[0], 0)
+
+    def test_nested_list_structure(self) -> None:
+        """Test that nested list structures are preserved"""
+        collate_fn = CollateFnWithEmpty(default_collate)
+
+        # First batch with list of tensors
+        batch = [
+            [torch.tensor([1, 2]), torch.tensor([3])],
+            [torch.tensor([4, 5]), torch.tensor([6])],
+        ]
+        result = collate_fn(batch)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+
+        # Empty batch should preserve list structure
+        empty_result = collate_fn([])
+
+        self.assertIsInstance(empty_result, list)
+        self.assertEqual(len(empty_result), 2)
+        self.assertEqual(empty_result[0].shape[0], 0)
+        self.assertEqual(empty_result[1].shape[0], 0)
+
+    def test_rand_on_empty_true(self) -> None:
+        """Test rand_on_empty=True generates random tensors with batch_size=1"""
+        collate_fn = CollateFnWithEmpty(default_collate, rand_on_empty=True)
+
+        # First process non-empty batch
+        batch = [torch.tensor([1, 2, 3])]
+        _ = collate_fn(batch)
+
+        # Empty batch should have batch_size=1 with random values
+        empty_result = collate_fn([])
+
+        self.assertTrue(torch.is_tensor(empty_result))
+        self.assertEqual(empty_result.shape[0], 1)  # Batch dimension should be 1
+        self.assertEqual(empty_result.shape[1], 3)  # Other dimensions preserved
+        # Values should be 0 or 1 (from torch.randint(0, 2, ...))
+        self.assertTrue(torch.all((empty_result == 0) | (empty_result == 1)))
+
+    def test_batch_first_false(self) -> None:
+        """Test batch_first=False puts batch dimension at index 1"""
+        collate_fn = CollateFnWithEmpty(default_collate, batch_first=False)
+
+        # First process non-empty batch - shape will be [batch, features]
+        batch = [torch.tensor([1, 2, 3])]
+        _ = collate_fn(batch)
+
+        # For empty batch with batch_first=False, batch dim should be at index 1
+        empty_result = collate_fn([])
+
+        self.assertTrue(torch.is_tensor(empty_result))
+        # With batch_first=False, shape should be [features, 0]
+        self.assertEqual(empty_result.shape[1], 0)
+
+    def test_no_collator_fn(self) -> None:
+        """Test with collator_fn=None returns batch as-is"""
+        collate_fn = CollateFnWithEmpty(None)
+
+        batch = [torch.tensor([1, 2]), torch.tensor([3, 4])]
+        result = collate_fn(batch)
+
+        # Without collator, should return list as-is
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+
+    def test_wrap_collate_with_empty_function(self) -> None:
+        """Test the wrap_collate_with_empty factory function"""
+        collate_fn = wrap_collate_with_empty(collate_fn=default_collate)
+
+        self.assertIsInstance(collate_fn, CollateFnWithEmpty)
+
+        # Test it works correctly
+        batch = [torch.tensor([1, 2])]
+        result = collate_fn(batch)
+        self.assertTrue(torch.is_tensor(result))
+
+    def test_multiple_empty_batches(self) -> None:
+        """Test that multiple empty batches can be processed"""
+        collate_fn = CollateFnWithEmpty(default_collate)
+
+        # First non-empty batch
+        batch = [torch.tensor([1, 2, 3])]
+        _ = collate_fn(batch)
+
+        # Multiple empty batches should work
+        for _ in range(3):
+            empty_result = collate_fn([])
+            self.assertTrue(torch.is_tensor(empty_result))
+            self.assertEqual(empty_result.shape[0], 0)
+
+    def test_tuple_preservation(self) -> None:
+        """Test that tuple structures are preserved"""
+
+        def tuple_collate(batch):
+            # Custom collator that returns tuples
+            x = default_collate([item[0] for item in batch])
+            y = default_collate([item[1] for item in batch])
+            return (x, y)
+
+        collate_fn = CollateFnWithEmpty(tuple_collate)
+
+        batch = [
+            (torch.tensor([1, 2]), torch.tensor([5])),
+            (torch.tensor([3, 4]), torch.tensor([6])),
+        ]
+        result = collate_fn(batch)
+
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+
+        # Empty batch should preserve tuple
+        empty_result = collate_fn([])
+
+        self.assertIsInstance(empty_result, tuple)
+        self.assertEqual(len(empty_result), 2)
+        self.assertEqual(empty_result[0].shape[0], 0)
+        self.assertEqual(empty_result[1].shape[0], 0)
+
+    def test_unsupported_type_raises_error(self) -> None:
+        """Test that unsupported batch types raise TypeError to preserve DP guarantees"""
+
+        def custom_collate(batch):
+            # Custom collator that returns an unsupported type (e.g., string)
+            if len(batch) > 0:
+                return "unsupported_type"
+            return ""
+
+        collate_fn = CollateFnWithEmpty(custom_collate)
+
+        # First process non-empty batch
+        batch = [torch.tensor([1, 2])]
+        _ = collate_fn(batch)
+
+        # Empty batch should raise TypeError for unsupported type
+        with self.assertRaises(TypeError) as context:
+            collate_fn([])
+
+        self.assertIn("Unsupported batch type", str(context.exception))
+
+    def test_empty_first_batch_shapes_match_dataset(self) -> None:
+        """Test zero-valued tensors have correct shapes and dtypes for multi-dim data"""
+        collate_fn = CollateFnWithEmpty(
+            default_collate,
+            sample_empty_shapes=[(0, 3, 4), (0, 5)],
+            dtypes=[torch.float64, torch.int32],
+        )
+
+        with self.assertLogs("opacus.data_loader", level="WARNING"):
+            result = collate_fn([])
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].shape, (0, 3, 4))
+        self.assertEqual(result[0].dtype, torch.float64)
+        self.assertEqual(result[1].shape, (0, 5))
+        self.assertEqual(result[1].dtype, torch.int32)
+        # All values should be zero
+        self.assertEqual(result[0].numel(), 0)
+        self.assertEqual(result[1].numel(), 0)
+
+    def test_empty_first_batch_then_normal_batches(self) -> None:
+        """Test transition: empty first batch returns zero tensors, then normal batches work"""
+        collate_fn = CollateFnWithEmpty(
+            default_collate,
+            sample_empty_shapes=[(0, 2)],
+            dtypes=[torch.float32],
+        )
+
+        # First batch is empty -> zero tensors fallback
+        with self.assertLogs("opacus.data_loader", level="WARNING"):
+            result = collate_fn([])
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].shape, (0, 2))
+
+        # Second batch is non-empty -> learns structure
+        batch = [torch.tensor([1.0, 2.0]), torch.tensor([3.0, 4.0])]
+        result = collate_fn(batch)
+        self.assertTrue(torch.is_tensor(result))
+        self.assertEqual(result.shape, (2, 2))
+
+        # Third batch is empty -> uses learned structure via _make_empty_batch
+        result = collate_fn([])
+        self.assertTrue(torch.is_tensor(result))
+        self.assertEqual(result.shape[0], 0)
+        self.assertEqual(result.shape[1], 2)
+
+
+class DPDataLoaderEmptyFirstBatchTest(unittest.TestCase):
+    """Tests for DPDataLoader when the first batch is empty"""
+
+    def test_empty_first_batch_with_dp_dataloader(self) -> None:
+        """End-to-end test: DPDataLoader with empty first batch returns zero-valued tensors"""
+        data_size = 10
+        dimension = 7
+        num_classes = 11
+
+        x = torch.randn(data_size, dimension)
+        y = torch.randint(low=0, high=num_classes, size=(data_size,))
+        dataset = TensorDataset(x, y)
+
+        # seed=0, sample_rate=0.05 on 10 items produces empty first batch
+        generator = torch.Generator().manual_seed(0)
+        data_loader = DPDataLoader(dataset, sample_rate=0.05, generator=generator)
+
+        batches = []
+        with self.assertLogs("opacus.data_loader", level="WARNING") as log:
+            for batch in data_loader:
+                batches.append(batch)
+
+        # First batch should be a list of zero-valued tensors (empty first batch fallback)
+        first_batch = batches[0]
+        self.assertIsInstance(first_batch, list)
+        self.assertEqual(len(first_batch), 2)
+        # x tensor: shape (0, 7), float32
+        self.assertEqual(first_batch[0].shape, (0, dimension))
+        self.assertEqual(first_batch[0].dtype, x.dtype)
+        # y tensor: shape (0,), int64
+        self.assertEqual(first_batch[1].shape, (0,))
+        self.assertEqual(first_batch[1].dtype, y.dtype)
+
+        # Verify warning was logged
+        self.assertTrue(
+            any("First batch is empty" in message for message in log.output)
+        )
+
+        # Subsequent non-empty batches should work normally
+        non_empty_found = False
+        for batch in batches[1:]:
+            if torch.is_tensor(batch[0]) and batch[0].shape[0] > 0:
+                non_empty_found = True
+                self.assertEqual(batch[0].shape[1], dimension)
+        self.assertTrue(
+            non_empty_found,
+            "Expected at least one non-empty batch after the first empty one",
+        )

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -23,6 +23,7 @@ from typing import Optional, OrderedDict
 from unittest.mock import MagicMock, patch
 
 import hypothesis.strategies as st
+import pytest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -806,6 +807,7 @@ class PrivacyEngineConvNetTest(BasePrivacyEngineTest, unittest.TestCase):
         return SampleConvNet()
 
 
+@pytest.mark.skip(("Incompatible with the new empty batch handling"))
 class PrivacyEngineConvNetEmptyBatchTest(PrivacyEngineConvNetTest):
     def setUp(self) -> None:
         super().setUp()

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -23,7 +23,6 @@ from typing import Optional, OrderedDict
 from unittest.mock import MagicMock, patch
 
 import hypothesis.strategies as st
-import pytest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -807,7 +806,7 @@ class PrivacyEngineConvNetTest(BasePrivacyEngineTest, unittest.TestCase):
         return SampleConvNet()
 
 
-@pytest.mark.skip(("Incompatible with the new empty batch handling"))
+@unittest.skip("Incompatible with the new empty batch handling")
 class PrivacyEngineConvNetEmptyBatchTest(PrivacyEngineConvNetTest):
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
Summary: Fixing external PR: D91500466 which introduced a pytest dependency.

Differential Revision: D98305588
