### PR TITLE
Fix docs CI: upgrade to Node 22 for yarn install compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,10 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -28,7 +31,7 @@ jobs:
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -15,7 +15,10 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Summary:
**Context:**
GitHub issue https://github.com/meta-pytorch/opacus/issues/818 reports that the documentation build fails during `yarn install` due to a Node.js version incompatibility introduced by a dependency update in #817.

**Motivation:**
The `babel/helper-compilation-targets` package (resolved to `8.0.0-rc.5` via the `^8.0.0-alpha.14` range in `website/package.json`) now requires `node ^22.18.0 || >=24.11.0`. The CI workflows had no explicit `setup-node` step, so they ran on the runner's default Node 20, which does not satisfy this constraint. GitHub is also deprecating Node 20 actions starting June 2026.

**This diff:**
- Add `actions/setup-node@v4` with `node-version: '22'` to both `deploy.yml` and `test-deploy.yml`
- Upgrade `actions/checkout` from `v3` to `v4` in both workflows
- Upgrade `peaceiris/actions-gh-pages` from `v3` to `v4` in `deploy.yml`

Differential Revision: D105837434


