### PR TITLE
Include module name and type in validation error messages

### DIFF
--- a/opacus/tests/module_validator_test.py
+++ b/opacus/tests/module_validator_test.py
@@ -159,3 +159,46 @@ class ModuleValidator_test(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             ModuleValidator.fix(m, replace_bn_with_in=True, num_groups=4)
+
+    def test_validate_error_includes_module_name(self):
+        """Verify that validation errors include the module path and type."""
+        model = nn.Sequential(
+            OrderedDict(
+                [
+                    ("fc", nn.Linear(4, 8)),
+                    ("bn", nn.BatchNorm1d(8)),
+                ]
+            )
+        )
+        errors = ModuleValidator.validate(model)
+        self.assertGreater(len(errors), 0)
+        # The error message should contain the module name "bn" and type "BatchNorm1d"
+        error_message = str(errors[0])
+        self.assertIn("bn", error_message)
+        self.assertIn("BatchNorm1d", error_message)
+
+    def test_validate_error_includes_nested_module_name(self):
+        """Verify that validation errors include the full nested module path."""
+        model = nn.Sequential(
+            OrderedDict(
+                [
+                    (
+                        "block",
+                        nn.Sequential(
+                            OrderedDict(
+                                [
+                                    ("linear", nn.Linear(4, 8)),
+                                    ("norm", nn.BatchNorm1d(8)),
+                                ]
+                            )
+                        ),
+                    ),
+                ]
+            )
+        )
+        errors = ModuleValidator.validate(model)
+        self.assertGreater(len(errors), 0)
+        # The error message should contain the full path "block.norm"
+        error_message = str(errors[0])
+        self.assertIn("block.norm", error_message)
+        self.assertIn("BatchNorm1d", error_message)

--- a/opacus/validators/module_validator.py
+++ b/opacus/validators/module_validator.py
@@ -59,11 +59,17 @@ class ModuleValidator:
                 IllegalModuleConfigurationError("Model needs to be in training mode")
             )
         # 2. perform module specific validations for trainable modules.
-        # TODO: use module name here - it's useful part of error message
-        for _, sub_module in trainable_modules(module):
+        for module_name, sub_module in trainable_modules(module):
             if type(sub_module) in ModuleValidator.VALIDATORS:
                 sub_module_validator = ModuleValidator.VALIDATORS[type(sub_module)]
-                errors.extend(sub_module_validator(sub_module))
+                sub_errors = sub_module_validator(sub_module)
+                for err in sub_errors:
+                    # Prepend module name to error message for easier debugging
+                    err.args = (
+                        f"{module_name} ({type(sub_module).__name__}): {err.args[0]}",
+                        *err.args[1:],
+                    )
+                errors.extend(sub_errors)
         # raise/return as needed
         if strict and len(errors) > 0:
             raise UnsupportedModuleError(errors)


### PR DESCRIPTION
Previously, validation errors from ModuleValidator.validate() did not indicate which specific sub-module caused the failure. For models with many layers, this made debugging DP compatibility issues difficult — users had to manually inspect each layer to find the offending module.

This change prepends the module path and type to each validation error message. For example, instead of:
  'BatchNorm cannot support DP'
users now see:
  'encoder.layer.3.norm (BatchNorm2d): BatchNorm cannot support DP'

This makes it immediately clear which layer needs to be replaced, especially in large models with hundreds of sub-modules.

Addresses the TODO:
  'use module name here - it's useful part of error message'

## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
