### PR TITLE
Fix batch_first paths in DPMultiheadAttention

### DIFF
--- a/opacus/layers/dp_multihead_attention.py
+++ b/opacus/layers/dp_multihead_attention.py
@@ -206,8 +206,10 @@ class DPMultiheadAttention(nn.Module):
 
         if not self.batch_first:
             tgt_len, bsz, embed_dim = query.size()
+            key_seq_len = key.size(0)
         else:
             bsz, tgt_len, embed_dim = query.size()
+            key_seq_len = key.size(1)
 
         if embed_dim != self.embed_dim:
             raise ValueError(
@@ -253,13 +255,13 @@ class DPMultiheadAttention(nn.Module):
 
             if attn_mask.dim() == 2:
                 attn_mask = attn_mask.unsqueeze(0)
-                if list(attn_mask.size()) != [1, query.size(0), key.size(0)]:
+                if list(attn_mask.size()) != [1, tgt_len, key_seq_len]:
                     raise ValueError("The size of the 2D attn_mask is not correct.")
             elif attn_mask.dim() == 3:
                 if list(attn_mask.size()) != [
                     bsz * self.num_heads,
-                    query.size(0),
-                    key.size(0),
+                    tgt_len,
+                    key_seq_len,
                 ]:
                     raise ValueError("The size of the 3D attn_mask is not correct.")
             else:
@@ -352,7 +354,12 @@ class DPMultiheadAttention(nn.Module):
         assert list(attn_output.size()) == [bsz * self.num_heads, tgt_len, head_dim]
 
         if self.batch_first:
-            attn_output = attn_output.contiguous().view(bsz, tgt_len, embed_dim)
+            attn_output = (
+                attn_output.view(bsz, self.num_heads, tgt_len, head_dim)
+                .transpose(1, 2)
+                .contiguous()
+                .view(bsz, tgt_len, embed_dim)
+            )
         else:
             attn_output = (
                 attn_output.transpose(0, 1).contiguous().view(tgt_len, bsz, embed_dim)

--- a/opacus/tests/dp_layers/dp_multihead_attention_test.py
+++ b/opacus/tests/dp_layers/dp_multihead_attention_test.py
@@ -222,6 +222,89 @@ class DPMultiheadAttention_test(DPModules_test):
         tgt_seq_len=st.integers(1, 6),
         num_heads=st.integers(1, 3),
         bias=st.booleans(),
+        batch_first=st.booleans(),
+        attn_mask_dim=st.integers(2, 3),
+    )
+    @settings(deadline=60000)
+    def test_attn_mask_batch_first(
+        self,
+        batch_size: int,
+        src_seq_len: int,
+        tgt_seq_len: int,
+        num_heads: int,
+        bias: bool,
+        batch_first: bool,
+        attn_mask_dim: int,
+    ):
+        embed_dim = 4 * num_heads
+
+        attn = nn.MultiheadAttention(
+            embed_dim,
+            num_heads,
+            dropout=0.0,
+            bias=bias,
+            batch_first=batch_first,
+        )
+        dp_attn = DPMultiheadAttention(
+            embed_dim,
+            num_heads,
+            dropout=0.0,
+            bias=bias,
+            batch_first=batch_first,
+        )
+
+        dp_attn.load_state_dict(attn.state_dict())
+
+        if batch_first:
+            q = torch.randn(batch_size, tgt_seq_len, embed_dim)
+            k = torch.randn(batch_size, src_seq_len, embed_dim)
+            v = torch.randn(batch_size, src_seq_len, embed_dim)
+        else:
+            q = torch.randn(tgt_seq_len, batch_size, embed_dim)
+            k = torch.randn(src_seq_len, batch_size, embed_dim)
+            v = torch.randn(src_seq_len, batch_size, embed_dim)
+
+        if attn_mask_dim == 2:
+            attn_mask = torch.zeros(tgt_seq_len, src_seq_len, dtype=torch.bool)
+        else:
+            attn_mask = torch.zeros(
+                batch_size * num_heads, tgt_seq_len, src_seq_len, dtype=torch.bool
+            )
+
+        self.compare_forward_outputs(
+            attn,
+            dp_attn,
+            q,
+            k,
+            v,
+            output_names=("attn_out", "attn_out_weights"),
+            atol=1e-5,
+            rtol=1e-3,
+            key_padding_mask=None,
+            need_weights=True,
+            attn_mask=attn_mask,
+        )
+
+        self.compare_gradients(
+            attn,
+            dp_attn,
+            attn_train_fn,
+            q,
+            k,
+            v,
+            atol=1e-5,
+            rtol=1e-3,
+            key_padding_mask=None,
+            need_weights=True,
+            attn_mask=attn_mask,
+        )
+
+    @given(
+        batch_size=st.integers(1, 5),
+        src_seq_len=st.integers(1, 6),
+        tgt_seq_len=st.integers(1, 6),
+        num_heads=st.integers(1, 3),
+        bias=st.booleans(),
         add_bias_kv=st.booleans(),
         add_zero_attn=st.booleans(),
         kdim=st.integers(2, 8) | st.none(),


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

Fixes #774 (plus a closely-related `batch_first=True` regression that surfaced while adding the requested test coverage).

`DPMultiheadAttention.forward()` had two `batch_first`-related issues:

**1. `attn_mask` shape validation ignored `batch_first` (#774).** The check used `query.size(0)` / `key.size(0)` regardless of `batch_first`. When `batch_first=True` those return the batch size, so any valid 2D or 3D mask was incorrectly rejected. Fix: compute `tgt_len` and a parallel `key_seq_len` in a `batch_first`-aware way and reference them in the mask validation.

**2. Output reshape under `batch_first=True` permuted nothing.** The reshape called `.view(bsz, tgt_len, embed_dim)` directly on the `(bsz * num_heads, tgt_len, head_dim)` tensor without first transposing the head and sequence dims, so head positions got spliced into time positions — empirically `max|diff|` against `nn.MultiheadAttention` ≈ 0.96. Fix: explicit `(B*H, L, D) → (B, H, L, D) → (B, L, H, D) → (B, L, E)` via `view → transpose(1, 2) → contiguous → view`. The `batch_first=False` branch is unchanged.

Neither bug surfaced previously because the existing `test_attn` / `test_dp_attn` only exercise `batch_first=False` and never pass `attn_mask`. See #774 for the diagnostic discussion — @iden-kalemaj greenlit bundling both fixes here.

## How Has This Been Tested

Added `test_attn_mask_batch_first` (Hypothesis-based, matching the existing `test_attn` / `test_dp_attn` style) covering both `batch_first` modes and both 2D and 3D mask shapes, asserting output and gradient parity with `nn.MultiheadAttention`.

Verified locally on Python 3.12 / pytest 9.0.3:

- `opacus/tests/dp_layers/dp_multihead_attention_test.py` — 4 tests pass (3 existing + new `test_attn_mask_batch_first`)
- `opacus/tests/grad_samples/dp_multihead_attention_test.py` — passes
- `opacus/tests/validators/multihead_attention_test.py` — both validator tests pass

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.