### PR TITLE
patch bug in IAccountant len functions. Currently returns # of unique noise_multiplier values vs intended # of steps

### DIFF
--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -19,9 +19,9 @@ import logging
 from os.path import exists
 from typing import Any, Dict
 
-from benchmarks.benchmark_layer import run_layer_benchmark
-from benchmarks.layers import LayerType
-from benchmarks.utils import get_layer_set, get_path, save_results
+from benchmark.benchmark_layer import run_layer_benchmark
+from benchmark.layers import LayerType
+from benchmark.utils import get_layer_set, get_path, save_results
 
 
 logger = logging.getLogger(__name__)

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -19,9 +19,9 @@ import logging
 from os.path import exists
 from typing import Any, Dict
 
-from benchmark.benchmark_layer import run_layer_benchmark
-from benchmark.layers import LayerType
-from benchmark.utils import get_layer_set, get_path, save_results
+from benchmarks.benchmark_layer import run_layer_benchmark
+from benchmarks.layers import LayerType
+from benchmarks.utils import get_layer_set, get_path, save_results
 
 
 logger = logging.getLogger(__name__)

--- a/opacus/accountants/accountant.py
+++ b/opacus/accountants/accountant.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Mapping, TypeVar
 
 from opacus.optimizers import DPOptimizer
 
+
 T_state_dict = TypeVar("T_state_dict", bound=Mapping[str, Any])
 
 

--- a/opacus/accountants/accountant.py
+++ b/opacus/accountants/accountant.py
@@ -51,7 +51,6 @@ class IAccountant(abc.ABC):
         """
         pass
 
-
     @classmethod
     @abc.abstractmethod
     def mechanism(cls) -> str:
@@ -59,6 +58,7 @@ class IAccountant(abc.ABC):
         Accounting mechanism name
         """
         pass
+
 
     def __len__(self) -> int:
         """

--- a/opacus/accountants/accountant.py
+++ b/opacus/accountants/accountant.py
@@ -51,12 +51,6 @@ class IAccountant(abc.ABC):
         """
         pass
 
-    @abc.abstractmethod
-    def __len__(self) -> int:
-        """
-        Number of optimization steps taken so far
-        """
-        pass
 
     @classmethod
     @abc.abstractmethod
@@ -65,6 +59,12 @@ class IAccountant(abc.ABC):
         Accounting mechanism name
         """
         pass
+
+    def __len__(self) -> int:
+        """
+        Number of optimization steps taken so far
+        """
+        return sum(num_steps for _, _, num_steps in self.history)
 
     def get_optimizer_hook_fn(
         self, sample_rate: float

--- a/opacus/accountants/accountant.py
+++ b/opacus/accountants/accountant.py
@@ -19,7 +19,6 @@ from typing import Any, Callable, Mapping, TypeVar
 
 from opacus.optimizers import DPOptimizer
 
-
 T_state_dict = TypeVar("T_state_dict", bound=Mapping[str, Any])
 
 
@@ -58,7 +57,6 @@ class IAccountant(abc.ABC):
         Accounting mechanism name
         """
         pass
-
 
     def __len__(self) -> int:
         """

--- a/opacus/accountants/gdp.py
+++ b/opacus/accountants/gdp.py
@@ -67,9 +67,6 @@ class GaussianAccountant(IAccountant):
             delta=delta,
         )
 
-    def __len__(self):
-        return len(self.history)
-
     @classmethod
     def mechanism(cls) -> str:
         return "gdp"

--- a/opacus/accountants/prv.py
+++ b/opacus/accountants/prv.py
@@ -157,6 +157,3 @@ class PRVAccountant(IAccountant):
     @classmethod
     def mechanism(cls) -> str:
         return "prv"
-
-    def __len__(self):
-        return len(self.history)

--- a/opacus/accountants/rdp.py
+++ b/opacus/accountants/rdp.py
@@ -84,9 +84,6 @@ class RDPAccountant(IAccountant):
         eps, _ = self.get_privacy_spent(delta=delta, alphas=alphas)
         return eps
 
-    def __len__(self):
-        return len(self.history)
-
     @classmethod
     def mechanism(cls) -> str:
         return "rdp"

--- a/opacus/tests/accountants_test.py
+++ b/opacus/tests/accountants_test.py
@@ -129,6 +129,30 @@ class AccountingTest(unittest.TestCase):
         epsilon = accountant.get_epsilon(delta=1e-5)
         self.assertAlmostEqual(epsilon, 6.777395712150674)
 
+    def test_len_counts_optimization_steps(self) -> None:
+        noise_multiplier = 1.5
+        sample_rate = 0.04
+        steps = 50
+
+        for accountant in (RDPAccountant(), GaussianAccountant(), PRVAccountant()):
+            for _ in range(steps):
+                accountant.step(
+                    noise_multiplier=noise_multiplier, sample_rate=sample_rate
+                )
+            self.assertEqual(len(accountant.history), 1)
+            self.assertEqual(len(accountant), steps)
+
+        for accountant in (RDPAccountant(), PRVAccountant()):
+            for _ in range(steps):
+                accountant.step(
+                    noise_multiplier=noise_multiplier, sample_rate=sample_rate
+                )
+            accountant.step(
+                noise_multiplier=noise_multiplier * 2, sample_rate=sample_rate
+            )
+            self.assertEqual(len(accountant.history), 2)
+            self.assertEqual(len(accountant), steps + 1)
+
     def test_get_noise_multiplier_rdp_epochs(self) -> None:
         delta = 1e-5
         sample_rate = 0.04


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change if dependent on len() == 1)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
Accountants currently implement __len__  with len(self.history). This means that len(accountant) is 1 or # of noise_multiplier changes vs the documented "Number of optimization steps taken so far" . This is because self.history is compact and the true step count is accumulated into self.history[:][2].
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->
I added iterative tests over existing accountants. For GDP, noise_multiplier changes raise a ValueError so it is ommitted from the noise_multiplier test.
I moved the fix into the base class since the contract for history is defined there. This should avoid future accountants from running into the same bug.

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
