### PR TITLE
Remove in-place operations in `ModuleValidator.fix()` for Opacus hooks compatibility (#831)

### DIFF
--- a/opacus/tests/inplace_test.py
+++ b/opacus/tests/inplace_test.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import operator
+import unittest
+
+import torch
+import torch.fx as fx
+import torch.nn as nn
+import torchvision
+from opacus import PrivacyEngine
+from opacus.validators import ModuleValidator
+from opacus.validators.inplace import _is_inplace_node, fix_inplace_operations
+
+
+def _clone(value):
+    return value.clone() if torch.is_tensor(value) else value
+
+
+def _inplace_node_count(module):
+    """Count remaining in-place method/function nodes in a traced module."""
+    if not isinstance(module, fx.GraphModule):
+        return 0
+    return sum(1 for node in module.graph.nodes if _is_inplace_node(node))
+
+
+# Model classes that flow through ModuleValidator.fix() must be defined at module
+# scope -- fix() clones via torch.save/load, which cannot pickle local classes.
+
+
+class _OpModule(nn.Module):
+    """Applies an in-place binary operator (e.g. ``operator.iadd``) to a fresh copy."""
+
+    def __init__(self, inplace_op):
+        super().__init__()
+        self._inplace_op = inplace_op
+
+    def forward(self, x, y):
+        return self._inplace_op(x.clone(), y)
+
+
+class _ResidualMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(8, 8)
+        self.fc2 = nn.Linear(8, 8)
+        self.act = nn.ReLU(inplace=True)
+
+    def forward(self, x):
+        out = self.act(self.fc1(x))
+        out = self.fc2(out)
+        out += x  # in-place residual
+        return self.act(out)
+
+
+class _DynamicControlFlow(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(4, 4)
+
+    def forward(self, x):
+        out = self.fc(x)
+        if out.sum() > 0:  # data-dependent control flow -> untraceable by fx
+            out = out * 2
+        out += x
+        return out
+
+
+class OperatorEquivalenceTest(unittest.TestCase):
+    """Each augmented-assignment operator must give identical results before/after
+    the rewrite (fx functionalizes these during tracing)."""
+
+    def _cases(self):
+        f = torch.randn(2, 3)
+        g = torch.randn(2, 3)
+        pos = torch.randn(2, 3).abs() + 1.0
+        i = torch.randint(1, 8, (2, 3))
+        j = torch.randint(1, 8, (2, 3))
+        # (name, inplace_op, x, y, exact_compare)
+        return [
+            ("iadd", operator.iadd, f, g, False),
+            ("isub", operator.isub, f, g, False),
+            ("imul", operator.imul, f, g, False),
+            ("itruediv", operator.itruediv, f, pos, False),
+            ("ifloordiv", operator.ifloordiv, f, pos, False),
+            ("imod", operator.imod, f.abs(), pos, False),
+            ("ipow", operator.ipow, pos, 2.0, False),
+            ("iand", operator.iand, i, j, True),
+            ("ior", operator.ior, i, j, True),
+            ("ixor", operator.ixor, i, j, True),
+            ("ilshift", operator.ilshift, i, 1, True),
+            ("irshift", operator.irshift, i, 1, True),
+        ]
+
+    def test_each_operator_is_equivalent(self):
+        for name, inplace_op, x, y, exact in self._cases():
+            with self.subTest(operator=name):
+                module = _OpModule(inplace_op)
+                eager = module(x.clone(), _clone(y))
+
+                fixed = fix_inplace_operations(module)
+                self.assertIsInstance(fixed, fx.GraphModule)
+                # tracing made the augmented op out-of-place: nothing left in-place
+                remaining = [
+                    str(n.target) for n in fixed.graph.nodes if _is_inplace_node(n)
+                ]
+                self.assertEqual(remaining, [], f"{name}: remaining={remaining}")
+
+                out = fixed(x.clone(), _clone(y))
+                if exact:
+                    self.assertTrue(torch.equal(eager, out))
+                else:
+                    self.assertTrue(torch.allclose(eager, out))
+
+
+class MethodAndFunctionEquivalenceTest(unittest.TestCase):
+    """In-place methods / functions / special cases preserve forward outputs and
+    are rewritten out-of-place. These call fix_inplace_operations directly, so
+    local model classes are fine (no clone/pickle)."""
+
+    def _assert_equivalent(self, module, *inputs, exact=False):
+        eager = module(*[_clone(i) for i in inputs])
+        fixed = fix_inplace_operations(module)
+        self.assertIsInstance(fixed, fx.GraphModule)
+        self.assertEqual(_inplace_node_count(fixed), 0)
+        out = fixed(*[_clone(i) for i in inputs])
+        if exact:
+            self.assertTrue(torch.equal(eager, out))
+        else:
+            self.assertTrue(torch.allclose(eager, out))
+        return fixed
+
+    def test_method_add(self):
+        class M(nn.Module):
+            def forward(self, x, y):
+                return x.clone().add_(y)
+
+        self._assert_equivalent(M(), torch.randn(2, 3), torch.randn(2, 3))
+
+    def test_method_clamp(self):
+        class M(nn.Module):
+            def forward(self, x):
+                return x.clone().clamp_(min=0.0)
+
+        self._assert_equivalent(M(), torch.randn(2, 3))
+
+    def test_method_masked_fill(self):
+        class M(nn.Module):
+            def forward(self, x, mask):
+                return x.clone().masked_fill_(mask, 0.0)
+
+        mask = torch.tensor([[True, False, True], [False, True, False]])
+        self._assert_equivalent(M(), torch.randn(2, 3), mask)
+
+    def test_functional_relu_(self):
+        class M(nn.Module):
+            def forward(self, x):
+                return torch.relu_(x.clone())
+
+        fixed = self._assert_equivalent(M(), torch.randn(2, 3))
+        self.assertIn(torch.relu, [n.target for n in fixed.graph.nodes])
+
+    def test_special_case_zero(self):
+        class M(nn.Module):
+            def forward(self, x):
+                return x.clone().zero_()
+
+        out = fix_inplace_operations(M())(torch.randn(2, 3))
+        self.assertTrue(torch.equal(out, torch.zeros(2, 3)))
+
+    def test_special_case_fill(self):
+        class M(nn.Module):
+            def forward(self, x):
+                return x.clone().fill_(3.0)
+
+        out = fix_inplace_operations(M())(torch.randn(2, 3))
+        self.assertTrue(torch.equal(out, torch.full((2, 3), 3.0)))
+
+    def test_special_case_copy(self):
+        class M(nn.Module):
+            def forward(self, x, src):
+                return x.clone().copy_(src)
+
+        src = torch.randn(2, 3)
+        out = fix_inplace_operations(M())(torch.randn(2, 3), src.clone())
+        self.assertTrue(torch.allclose(out, src))
+
+    def test_special_case_copy_is_independent_of_src(self):
+        # copy_ writes into x's own storage; the rewrite must not alias src.
+        class M(nn.Module):
+            def forward(self, x, src):
+                return x.clone().copy_(src)
+
+        src = torch.zeros(2, 3)
+        out = fix_inplace_operations(M())(torch.randn(2, 3), src)
+        src.add_(1.0)  # mutating src must not change a faithful copy_ result
+        self.assertTrue(torch.equal(out, torch.zeros(2, 3)))
+
+    def test_special_case_copy_casts_to_destination_dtype(self):
+        # copy_ casts src to the destination's dtype; the rewrite must preserve that
+        # so downstream dtypes don't silently change for cross-dtype copies.
+        class M(nn.Module):
+            def forward(self, x, src):
+                return x.clone().copy_(src)
+
+        x = torch.zeros(2, 3, dtype=torch.float32)
+        src = torch.ones(2, 3, dtype=torch.float64)
+        eager = M()(x.clone(), src.clone())
+        out = fix_inplace_operations(M())(x.clone(), src.clone())
+        self.assertEqual(eager.dtype, torch.float32)
+        self.assertEqual(out.dtype, torch.float32)
+        self.assertTrue(torch.equal(eager, out))
+
+    def test_requires_grad_left_unchanged(self):
+        # requires_grad_ strips to the requires_grad property (not callable), so it
+        # must be left as-is rather than rewritten into a broken method call.
+        class M(nn.Module):
+            def forward(self, x):
+                return x.clone().requires_grad_()
+
+        with self.assertWarns(UserWarning):
+            fixed = fix_inplace_operations(M())
+        self.assertIn("requires_grad_", [str(n.target) for n in fixed.graph.nodes])
+        self.assertEqual(fixed(torch.randn(2, 3)).shape, (2, 3))
+
+
+class LeaveUnchangedTest(unittest.TestCase):
+    """In-place ops with no safe out-of-place form are left as-is (and warned
+    about), keeping their original semantics via tensor aliasing."""
+
+    def test_statement_form_preserved_and_warns(self):
+        class M(nn.Module):
+            def forward(self, x, mask):
+                x.masked_fill_(mask, 0.0)  # bare statement -> dropped by tracing
+                return x.softmax(dim=-1)
+
+        mask = torch.tensor([[True, False, True], [False, True, False]])
+        x = torch.randn(2, 3)
+        eager = M()(x.clone(), mask)
+        with self.assertWarns(UserWarning):
+            fixed = fix_inplace_operations(M())
+        self.assertTrue(torch.allclose(eager, fixed(x.clone(), mask)))
+
+    def test_out_kwarg_preserved_and_warns(self):
+        class M(nn.Module):
+            def forward(self, x, y):
+                buf = torch.empty_like(x)
+                torch.add(x, y, out=buf)
+                return buf.relu()
+
+        x, y = torch.randn(2, 3), torch.randn(2, 3)
+        eager = M()(x.clone(), y.clone())
+        with self.assertWarns(UserWarning):
+            fixed = fix_inplace_operations(M())
+        self.assertTrue(torch.allclose(eager, fixed(x.clone(), y.clone())))
+
+    def test_aliased_self_read_downstream_left_unchanged(self):
+        # The mutated tensor (a) is read again after the in-place op, so rewriting
+        # add_ out-of-place would hide the mutation from that reader and change the
+        # result. It must be left in place (and warned about) instead.
+        class M(nn.Module):
+            def forward(self, x):
+                a = x.clone()
+                b = a.add_(1)  # a is read again below -> must NOT be rewritten
+                c = a.mul(2)
+                return b + c
+
+        x = torch.randn(2, 3)
+        eager = M()(x.clone())
+        with self.assertWarns(UserWarning):
+            fixed = fix_inplace_operations(M())
+        self.assertTrue(torch.allclose(eager, fixed(x.clone())))
+
+
+class FixIntegrationTest(unittest.TestCase):
+    """ModuleValidator.fix() behavior for in-place handling."""
+
+    def test_inplace_flags_always_disabled(self):
+        for remove_inplace_ops in (True, False):
+            with self.subTest(remove_inplace_ops=remove_inplace_ops):
+                model = nn.Sequential(nn.Linear(8, 8), nn.ReLU(inplace=True))
+                fixed = ModuleValidator.fix(
+                    model, remove_inplace_ops=remove_inplace_ops
+                )
+                for m in fixed.modules():
+                    if hasattr(m, "inplace"):
+                        self.assertFalse(m.inplace)
+
+    def test_residual_inplace_equivalence(self):
+        model = _ResidualMLP().eval()
+        x = torch.randn(4, 8)
+        eager = model(x.clone())
+
+        fixed = ModuleValidator.fix(model, remove_inplace_ops=True)
+        self.assertIsInstance(fixed, fx.GraphModule)
+        for m in fixed.modules():
+            if hasattr(m, "inplace"):
+                self.assertFalse(m.inplace)
+        self.assertTrue(torch.allclose(eager, fixed.eval()(x.clone()), atol=1e-6))
+
+    def test_fix_warns_when_returning_graph_module(self):
+        model = _ResidualMLP()
+
+        with self.assertWarnsRegex(
+            UserWarning,
+            r"(?s)torch\.fx.*GraphModule.*remove_inplace_ops=False",
+        ):
+            fixed = ModuleValidator.fix(model, remove_inplace_ops=True)
+
+        self.assertIsInstance(fixed, fx.GraphModule)
+
+    def test_untraceable_model_falls_back(self):
+        model = _DynamicControlFlow()
+        with self.assertLogs("opacus.validators.inplace", level="INFO"):
+            fixed = ModuleValidator.fix(model, remove_inplace_ops=True)
+        # tracing failed -> not a GraphModule, but still runnable
+        self.assertNotIsInstance(fixed, fx.GraphModule)
+        self.assertEqual(fixed(torch.randn(2, 4)).shape, (2, 4))
+
+
+class ResNetEndToEndTest(unittest.TestCase):
+    """The originally reported crash: ResNet under the default hooks mode."""
+
+    def test_fixed_resnet_trains_under_hooks(self):
+        model = torchvision.models.resnet18(num_classes=10)
+        model = ModuleValidator.fix(model, remove_inplace_ops=True)
+        self.assertTrue(ModuleValidator.is_valid(model))
+        model.train()
+
+        dataset = torch.utils.data.TensorDataset(
+            torch.randn(8, 3, 32, 32), torch.randint(0, 10, (8,))
+        )
+        # Citrine C0: pin_memory=True for efficient CPU-to-GPU transfer
+        data_loader = torch.utils.data.DataLoader(
+            dataset, batch_size=4, pin_memory=True
+        )
+        # Citrine C2: foreach=True for multi-tensor optimizer execution
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1, foreach=True)
+
+        privacy_engine = PrivacyEngine()
+        model, optimizer, data_loader = privacy_engine.make_private(
+            module=model,
+            optimizer=optimizer,
+            data_loader=data_loader,
+            noise_multiplier=1.0,
+            max_grad_norm=1.0,
+            grad_sample_mode="hooks",
+        )
+
+        criterion = nn.CrossEntropyLoss()
+        data, target = next(iter(data_loader))
+        optimizer.zero_grad()
+        loss = criterion(model(data), target)
+        loss.backward()  # this is where the original crash happened
+        optimizer.step()
+        self.assertTrue(torch.isfinite(loss))

--- a/opacus/validators/inplace.py
+++ b/opacus/validators/inplace.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities to make a model free of in-place operations.
+
+Opacus' hooks-based grad_sample modes attach ``register_full_backward_hook`` to
+each trainable module. That wraps the module's output in a custom autograd
+``Function`` whose result is a view, and autograd forbids in-place writes to such
+a view -- hence ``RuntimeError: Output 0 of BackwardHookFunction is a view and is
+being modified inplace``. This module removes the two sources of in-place writes:
+module-level in-place activations (the ``inplace`` flag) and functional/tensor
+in-place ops baked into ``forward`` (e.g. a ResNet's ``out += identity``).
+"""
+
+import logging
+import operator
+import warnings
+
+import torch
+import torch.fx as fx
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+logger = logging.getLogger(__name__)
+
+
+def disable_inplace(module: nn.Module) -> None:
+    """Recursively turn off the ``inplace`` flag on every submodule that has it.
+
+    Handles module-based in-place activations (nn.ReLU(inplace=True), SiLU,
+    Hardtanh, Dropout, ...). Does NOT handle functional/tensor in-place ops baked
+    into a forward() method (e.g. ResNet's ``out += identity``) -- see
+    fix_inplace_operations.
+    """
+    for child in module.modules():
+        if getattr(child, "inplace", False):
+            child.inplace = False
+
+
+def _is_inplace_name(name: str) -> bool:
+    """A single trailing underscore marks an in-place op (``add_``), but not a dunder."""
+    return name.endswith("_") and not name.endswith("__")
+
+
+def _is_inplace_function(target: object) -> bool:
+    """True if a ``call_function`` target is an in-place op (trailing-underscore name).
+
+    Excludes ``operator`` builtins whose trailing underscore only avoids a Python
+    keyword and are out-of-place (``operator.and_``, ``operator.or_``, ...): for
+    those, ``getattr(operator, name)`` is the target itself.
+    """
+    name = getattr(target, "__name__", "")
+    if not _is_inplace_name(name):
+        return False
+    return getattr(operator, name, None) is not target
+
+
+def _outofplace_function(target: object) -> object:
+    """Map a functional in-place op (``torch.relu_``) to its out-of-place twin.
+
+    Looks the stripped name up in ``torch`` and ``torch.nn.functional`` so both
+    ``torch.relu_`` and ``F.relu_`` resolve. Returns None if no twin exists.
+    """
+    if not _is_inplace_function(target):
+        return None
+    stripped = target.__name__[:-1]
+    for namespace in (torch, F):
+        candidate = getattr(namespace, stripped, None)
+        if callable(candidate):
+            return candidate
+    return None
+
+
+def _rewrite_zero(node: fx.Node) -> None:
+    # x.zero_() -> torch.zeros_like(x)
+    node.op = "call_function"
+    node.target = torch.zeros_like
+    node.args = (node.args[0],)
+    node.kwargs = {}
+
+
+def _rewrite_fill(node: fx.Node) -> None:
+    # x.fill_(v) -> torch.full_like(x, v)
+    value = node.args[1] if len(node.args) > 1 else node.kwargs["value"]
+    node.op = "call_function"
+    node.target = torch.full_like
+    node.args = (node.args[0], value)
+    node.kwargs = {}
+
+
+def _rewrite_copy(node: fx.Node) -> None:
+    # x.copy_(src) -> src.expand_as(x).type_as(x).clone(). copy_ broadcasts src to x's
+    # shape, casts it to x's dtype/device, and writes into x's own storage. type_as(x)
+    # reproduces that dtype/device cast (the concrete dtype is unknown while rewriting,
+    # so it is read from x at runtime); without it a cross-dtype copy_ would leak src's
+    # dtype downstream. .clone() gives the result independent, contiguous storage so it
+    # behaves like copy_ rather than aliasing src.
+    self_node = node.args[0]
+    src = node.args[1] if len(node.args) > 1 else node.kwargs["src"]
+    node.target = "expand_as"
+    node.args = (src, self_node)
+    node.kwargs = {}
+    graph = node.graph
+    with graph.inserting_after(node):
+        type_as_node = graph.call_method("type_as", args=(node, self_node))
+    with graph.inserting_after(type_as_node):
+        clone_node = graph.call_method("clone", args=(type_as_node,))
+    node.replace_all_uses_with(clone_node)
+    # replace_all_uses_with also redirected the new nodes' own inputs to clone_node;
+    # point them back at their real upstream nodes.
+    type_as_node.args = (node, self_node)
+    clone_node.args = (type_as_node,)
+
+
+# In-place methods whose out-of-place form is not just the name minus "_".
+_METHOD_SPECIAL_CASES = {
+    "zero_": _rewrite_zero,
+    "fill_": _rewrite_fill,
+    "copy_": _rewrite_copy,
+}
+
+
+def _is_inplace_node(node: fx.Node) -> bool:
+    """True if ``node`` performs an in-place write (method, function, or out=).
+
+    Augmented-assignment operators (``out += x``) are NOT covered here: ``torch.fx``
+    functionalizes them to their out-of-place form while tracing, so they never
+    appear as in-place nodes -- the recompiled graph is already out-of-place. Note
+    that some out-of-place ``operator`` builtins carry a trailing underscore to
+    avoid Python keywords (``operator.and_``, ``operator.or_``); those are excluded
+    by ``_is_inplace_function``, not the raw trailing-underscore name check.
+    """
+    if node.op not in ("call_function", "call_method"):
+        return False
+    if node.kwargs.get("out") is not None:
+        return True
+    if node.op == "call_function":
+        return _is_inplace_function(node.target)
+    return isinstance(node.target, str) and _is_inplace_name(node.target)
+
+
+def _try_rewrite(node: fx.Node) -> bool:
+    """Rewrite an in-place node to its out-of-place form. Return True if rewritten.
+
+    Returns False (leaving the node as-is) when rewriting is unsafe: ``out=`` buffer
+    writes, an in-place method/function with no known equivalent, or a node whose
+    mutated tensor is also read elsewhere (rewriting out-of-place would hide the
+    mutation from those readers and silently change outputs).
+    """
+    if node.kwargs.get("out") is not None:
+        # The result flows through the caller's buffer, not this node's return, so
+        # we cannot drop ``out=`` without rewiring downstream users.
+        return False
+
+    # An in-place op writes into its first argument. If that tensor is read by any
+    # node other than this one, rewriting to the out-of-place form hides the
+    # mutation from those readers and silently changes outputs. Leave such nodes in
+    # place -- their aliasing semantics are preserved and they get reported.
+    self_node = node.args[0] if node.args else None
+    if isinstance(self_node, fx.Node) and len(self_node.users) > 1:
+        return False
+
+    if node.op == "call_function":
+        out_fn = _outofplace_function(node.target)
+        if out_fn is not None:
+            node.target = out_fn
+            return True
+        return False
+
+    # call_method
+    special = _METHOD_SPECIAL_CASES.get(node.target)
+    if special is not None:
+        special(node)
+        return True
+    stripped = node.target[:-1]
+    # require a callable twin: e.g. requires_grad_ strips to the property
+    # requires_grad, which must not be turned into a method call.
+    if callable(getattr(torch.Tensor, stripped, None)):
+        node.target = stripped
+        return True
+    return False
+
+
+def fix_inplace_operations(module: nn.Module) -> nn.Module:
+    """Return a module with functional/tensor in-place operations made out-of-place.
+
+    The module is symbolically traced with ``torch.fx`` and recompiled, which
+    accomplishes the rewrite in two ways:
+
+      - augmented-assignment operators are functionalized by tracing itself
+        (``out += x`` becomes ``out = out + x`` in the recompiled graph), and
+      - in-place methods/functions are rewritten explicitly: ``x.add_()`` ->
+        ``x.add()``, ``torch.relu_`` / ``F.relu_`` -> ``torch.relu``, and the
+        special cases ``x.zero_()`` -> ``torch.zeros_like(x)``, ``x.fill_(v)`` ->
+        ``torch.full_like(x, v)``, ``x.copy_(src)`` -> ``src.expand_as(x).clone()``.
+
+    An in-place method/function is rewritten only when it is safe: its result is
+    consumed (so the out-of-place value flows downstream) AND a known out-of-place
+    form exists. In-place ops that are left untouched keep their original semantics
+    via tensor aliasing and only fail if their tensor is wrapped by an Opacus
+    backward hook; they are reported via a warning that distinguishes ops with no
+    known out-of-place form from ops whose result is unused.
+
+    If the module cannot be symbolically traced (e.g. data-dependent control flow,
+    as in attention/transformer blocks), this is logged at INFO and the module is
+    returned unchanged. On a successful trace the returned object is an
+    ``fx.GraphModule``.
+
+    Args:
+        module: The module to rewrite. Module-level ``inplace`` flags are expected
+            to have been cleared already (see :func:`disable_inplace`).
+
+    Returns:
+        The rewritten ``fx.GraphModule``, or the original ``module`` if tracing failed.
+    """
+    try:
+        graph_module = fx.symbolic_trace(module)
+    except Exception:
+        logger.info(
+            "If the model has in-place operations, "
+            "these may cause errors during the backward pass with Opacus. If so, consider rewriting the model "
+            "to replace those in-place operations with out-of-place ones. "
+        )
+        return module
+
+    aliased = []  # zero users: side effect only observed via tensor aliasing
+    out_buffer = (
+        []
+    )  # writes into a caller-provided out= buffer; can't drop without rewiring
+    unrewritable = []  # has users but no known out-of-place twin / self read elsewhere
+    for node in graph_module.graph.nodes:
+        if not _is_inplace_node(node):
+            continue
+        # Zero users means symbolic_trace did not thread the mutation into the
+        # dataflow; rewriting out-of-place would discard it, so leave it in place
+        # (codegen re-emits it and the aliased write is still observed downstream).
+        if len(node.users) == 0:
+            aliased.append(node.format_node())
+        elif node.kwargs.get("out") is not None:
+            out_buffer.append(node.format_node())
+        elif not _try_rewrite(node):
+            unrewritable.append(node.format_node())
+
+    if aliased or out_buffer or unrewritable:
+        details = []
+        if unrewritable:
+            details.append("no safe out-of-place form for: " + "; ".join(unrewritable))
+        if out_buffer:
+            details.append(
+                "result written into a caller-provided out= buffer, dropping out= "
+                "would require rewiring downstream users: " + "; ".join(out_buffer)
+            )
+        if aliased:
+            details.append(
+                "result unused so tracing dropped the rewrite, the in-place write "
+                "is still observed via aliasing: " + "; ".join(aliased)
+            )
+        warnings.warn(
+            "fix_inplace_operations left some in-place ops unchanged. They are fine "
+            "unless their tensor is wrapped by an Opacus backward hook, in which "
+            "case autograd raises at runtime.\n  " + "\n  ".join(details),
+        )
+
+    graph_module.graph.lint()
+    graph_module.recompile()
+    return graph_module

--- a/opacus/validators/module_validator.py
+++ b/opacus/validators/module_validator.py
@@ -14,14 +14,17 @@
 # limitations under the License.
 
 import logging
+import warnings
 from typing import List
 
+import torch.fx as fx
 import torch.nn as nn
 from opacus.utils.module_utils import clone_module, get_submodule, trainable_modules
 from opacus.validators.errors import (
     IllegalModuleConfigurationError,
     UnsupportedModuleError,
 )
+from opacus.validators.inplace import disable_inplace, fix_inplace_operations
 
 
 logger = logging.getLogger(__name__)
@@ -84,16 +87,59 @@ class ModuleValidator:
         return len(cls.validate(module, strict=False)) == 0
 
     @classmethod
-    def fix(cls, module: nn.Module, **kwargs) -> nn.Module:
+    def fix(
+        cls, module: nn.Module, *, remove_inplace_ops: bool = False, **kwargs
+    ) -> nn.Module:
         """
         Make the module and sub_modules DP compatible by running registered custom fixers.
 
+        In addition to the per-module-type fixers, this always disables in-place
+        activation flags (e.g. ``nn.ReLU(inplace=True)``) since in-place writes are
+        incompatible with Opacus' backward hooks. This is a cheap, type-preserving
+        fix that requires no tracing.
+
+        Functional/tensor in-place ops baked into ``forward`` (e.g. a ResNet's
+        ``out += identity``) are only rewritten when ``remove_inplace_ops=True``,
+        because doing so requires symbolic tracing and changes the returned type.
+        It is opt-in: models without such ops (or whose only in-place ops are the
+        activation flags handled above) do not need it. If your model crashes under
+        ``grad_sample_mode="hooks"`` with ``RuntimeError: Output 0 of
+        BackwardHookFunction is a view and is being modified inplace``, re-run with
+        ``remove_inplace_ops=True``.
+
+        When ``remove_inplace_ops=True`` and tracing succeeds, the returned object
+        is a ``torch.fx.GraphModule``, not the original ``nn.Module`` subclass.
+        ``GraphModule`` is a subclass of ``nn.Module`` and preserves forward outputs
+        for typical models, but ``isinstance`` checks against the original class,
+        custom methods defined on the original class, pickling by class name, and
+        similar type-dependent code will observe the GraphModule type instead. A
+        warning is emitted in this case.
+
+        FX tracing also records a single execution path: data-independent control
+        flow in the root ``forward`` (e.g. ``if self.training``) is frozen to the
+        branch taken during tracing, so a later ``.train()``/``.eval()`` toggle may
+        have no effect. Standard ``nn.Dropout``/``nn.BatchNorm`` submodules keep
+        their own flags and are unaffected.
+
+        Rewriting replaces in-place writes with out-of-place equivalents. Forward
+        outputs are preserved, but aliasing semantics change: a tensor mutated in
+        place is instead replaced by a new tensor, so other aliases to the original
+        storage will not see the update. Code relying on in-place side effects via
+        aliasing may diverge in behavior.
+
+        Models that cannot be symbolically traced (e.g. data-dependent control flow)
+        are returned unchanged and the fallback is logged at INFO level.
+
         Args:
             module: The root module to be made compatible.
-            **kwargs: Arbitrary keyword arguments.
+            remove_inplace_ops: If True, rewrite functional/tensor in-place ops
+                out-of-place via symbolic tracing. Defaults to False. No-op if the
+                module cannot be traced.
+            **kwargs: Arbitrary keyword arguments forwarded to the per-module fixers.
 
         Returns:
-            Fixed module.
+            Fixed module. Type is ``torch.fx.GraphModule`` when tracing succeeds with
+            ``remove_inplace_ops=True``, otherwise the original (cloned) ``nn.Module`` type.
         """
         module = clone_module(module)
         # iterate over all sub_modules
@@ -120,6 +166,29 @@ class ModuleValidator:
                 logger.info(
                     f"Replaced sub_module {sub_module_name} : {sub_module}"
                     f" with {new_sub_module}"
+                )
+        # in-place writes are incompatible with Opacus' backward hooks: always
+        # disable in-place activation flags, and optionally rewrite functional
+        # in-place ops (e.g. ``out += identity``) out-of-place.
+        disable_inplace(module)
+        if remove_inplace_ops:
+            module = fix_inplace_operations(module)
+            if isinstance(module, fx.GraphModule):
+                warnings.warn(
+                    "ModuleValidator.fix() traced your model with torch.fx to rewrite "
+                    "any in-place operations out-of-place. Because of this, the returned "
+                    "model is now a torch.fx.GraphModule instead of its original type. "
+                    "Two things to be aware of:\n"
+                    "  1. Anything that checks the model's type -- isinstance checks, "
+                    "custom methods on your model class, or pickling -- may not behave "
+                    "as before.\n"
+                    "  2. If your model's forward() uses an if/else on a flag such as "
+                    "self.training, tracing keeps only the branch taken while tracing, "
+                    "so switching between .train() and .eval() afterwards may have no "
+                    "effect. (Standard layers like Dropout and BatchNorm are not "
+                    "affected.)\n"
+                    "To skip tracing and keep your model's original type, call "
+                    "ModuleValidator.fix(..., remove_inplace_ops=False).",
                 )
         # return fixed module
         return module


### PR DESCRIPTION
Summary:

Opacus backward passes throws an error whenever the model contains in-place operations: https://github.com/meta-pytorch/opacus/issues/828. 

Opacus' default `hooks` grad-sample mode attaches `register_full_backward_hook` to each trainable module. `register_full_backward_hook` is incompatible with in-place operations and there is no clear workaround: https://github.com/pytorch/pytorch/issues/61519. We replaced `register_backward_hook` with `register_full_backward_hook` since the former is being deprecated and might be inaccurate: https://github.com/meta-pytorch/opacus/pull/653

We propose an approach where we modify the model to replace inplace operations where possible. The fixes are inside of `ModuleValidator.fix()`:

- It always clears module-level in-place activation flags (`disable_inplace`), e.g. `nn.ReLU(inplace=True)`.
- A new `remove_inplace_ops` kwarg (default `False`) rewrites functional/tensor in-place ops out-of-place via symbolic tracing in`torch.fx`. In-place ops with no safe out-of-place form are left untouched and reported via a warning.

If a model cannot be symbolically traced (e.g. data-dependent control flow, as in attention/transformer blocks), `fix_inplace_operations` logs an INFO and returns the model unchanged, so untraceable models never regress. 

Gaps:
- This does not fix all in-place operations. We expect that standard implementations of transformer models would not contain in-place operations for tensors that require gradients.  
- When a model is traceable, ModuleValidator.fix() returns a `torch.fx.GraphModule` which can break `isinstance` or other type-related functions. We log a warning in this case and give users the ability to disable the behavior. Still, FX tracing was the most stable and comprehensive solution we found for automatically replacing inplace operations. 

The other alternative is to return to `register_backward_hook`. This is undesirable because PyTorch does not guarantee that `register_backward_hook` computes gradients correctly and can lead to silent failures. We will monitor whether the current fix is sufficient or causes any regressions.

Differential Revision: D109063733


