### PR TITLE
Enable test_generate_noise_in_secure_mode

### DIFF
--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -738,7 +738,6 @@ class BasePrivacyEngineTest(ABC):
             secure_mode=secure_mode,
         )
 
-    @unittest.skip("requires torchcsprng compatible with new pytorch versions")
     @patch("torch.normal", MagicMock(return_value=torch.Tensor([0.6])))
     def test_generate_noise_in_secure_mode(self) -> None:
         """


### PR DESCRIPTION
Summary:
Removes the unittest.skip("requires torchcsprng compatible with new pytorch versions") decorator on test_generate_noise_in_secure_mode in privacy_engine_test.py, resolving the SKIPPING test issues in T276490753 (5 inheriting test classes).


The skip reason was inaccurate for this test: it mocks torch.normal and exercises the secure_mode branch of _generate_noise, which uses only torch.normal and a default generator=None — it never touches torchcsprng. The real csprng dependency lives in PrivacyEngine.__init__, which this test does not construct, so the test runs and passes without any csprng build fix.

The broader torchcsprng-dependent secure-mode tests (randomness_test.py and the secure_mode=st.just(False) case in test_noise_level) remain skipped pending a torchcsprng build compatible with the current PyTorch version.

Differential Revision: D110651190


