### PR TITLE
Use built in python-setup cache and version bump to fix flaky gpu build

### DIFF
--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -37,15 +37,19 @@ jobs:
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Display Python version
         run: python3 -c "import sys; print(sys.version)"
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            dev_requirements.txt
 
       - name: Install dependencies
         run: |
@@ -60,12 +64,16 @@ jobs:
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            dev_requirements.txt
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Types of changes

I am proposing a version bump and cache solution for a flaky and long running gpu integration test. The test itself is 3-5 minutes, the pip installation of tensorflow is ranging from 80 to 420 minutes, and sometimes failing.

A similar change can be done to the other ci_cpu.yml however I am scoping this to the flaky build unless instructed to do otherwise during review.


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

While completing https://github.com/meta-pytorch/opacus/pull/829 the gpu_integration build : 
- failed
- then took 423 minutes with 420 minutes on the pip installation of tensorboard

## How Has This Been Tested (if it applies)

These changes only take effect in github actions. The version bump should improve the first run. The cache should improve a rerun.

The build can take < 3 minutes for the install. The current installation takes ~80 minutes if it does not fail. The most recent merge to main failed on main.

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
