### PR TITLE
Update flake8 config path in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ enforce a common code style across the code base. black is installed easily via
 pip using `pip install black`, and run locally by calling
 ```bash
 black .
-flake8 --config ./.circleci/flake8_config.ini
+flake8 --config ./.github/workflows/flake8_config.ini
 ```
 from the repository root. No additional configuration should be needed (see the
 [black documentation](https://black.readthedocs.io/en/stable/installation_and_usage.html#usage)


### PR DESCRIPTION
Summary:
The flake8 config file moved from .circleci/flake8_config.ini to
.github/workflows/flake8_config.ini (the .circleci directory no longer
exists; CI now runs via GitHub workflows). Update the local lint command
in CONTRIBUTING.md to reference the new path, matching what CI uses in
.github/workflows/ci_cpu.yml.

Differential Revision: D111349465


