### PR TITLE
Update versions for actions and cache cifar10 and mnist data downloads for faster builds

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: '3.9'
       - name: Install dependencies
@@ -39,9 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -57,7 +57,7 @@ jobs:
           # Format into xml to be used for coveralls
           coverage xml -i
       - name: Store test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unittest-py310-release-reports
           path: unittest-py310-release-reports
@@ -72,9 +72,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
       - name: Install dependencies
@@ -88,7 +88,7 @@ jobs:
           coverage run -m pytest --doctest-modules -p conftest opacus
           coverage xml -i
       - name: Store test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unittest-py39-release-reports
           path: unittest-py39-release-reports
@@ -103,9 +103,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
       - name: Install dependencies
@@ -122,9 +122,9 @@ jobs:
     if: ${{ github.event_name == 'schedule' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
       - name: Install dependencies
@@ -137,7 +137,7 @@ jobs:
           mkdir unittest-py39-nightly-reports
           python -m pytest --doctest-modules -p conftest --junitxml=unittest-py39-nightly-reports/junit.xml opacus
       - name: Store test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unittest-py39-nightly-reports
           path: unittest-py39-nightly-reports
@@ -147,9 +147,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
       - name: Install dependencies
@@ -166,7 +166,7 @@ jobs:
           coverage report -i -m
           coverage xml -i
       - name: Store test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mnist-cpu-reports
           path: runs/mnist/test-reports
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Finish Coveralls Parallel
         uses: coverallsapp/github-action@v2
         with:

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -118,7 +118,9 @@ jobs:
       - name: Cache CIFAR10 dataset
         uses: actions/cache@v5
         with:
-          path: runs/cifar10/data
+          path: |
+            runs/cifar10/data
+            !runs/cifar10/data/cifar-10-python.tar.gz
           key: cifar10-dataset
 
       - name: Run CIFAR10 integration test (CUDA)

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -37,13 +37,13 @@ jobs:
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Display Python version
         run: python3 -c "import sys; print(sys.version)"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
           cache: 'pip'
@@ -64,10 +64,10 @@ jobs:
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.9'
           cache: 'pip'
@@ -92,6 +92,12 @@ jobs:
       #       libcudnn8=8.1.1.33-1+cuda11.1 \
       #       libcudnn8-dev=8.1.1.33-1+cuda11.1
 
+      - name: Cache MNIST dataset
+        uses: actions/cache@v5
+        with:
+          path: runs/mnist/data
+          key: mnist-dataset
+
       - name: Run MNIST integration test (CUDA)
         run: |
           nvidia-smi
@@ -102,10 +108,16 @@ jobs:
           python -c "import torch; accuracy = torch.load('run_results_mnist_0.25_0.7_1.5_64_1.pt'); exit(0) if (accuracy[0]>0.78 and accuracy[0]<0.95) else exit(1)"
 
       - name: Store MNIST test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mnist-gpu-reports
           path: runs/mnist/test-reports
+
+      - name: Cache CIFAR10 dataset
+        uses: actions/cache@v5
+        with:
+          path: runs/cifar10/data
+          key: cifar10-dataset
 
       - name: Run CIFAR10 integration test (CUDA)
         run: |
@@ -119,7 +131,7 @@ jobs:
           python -c "import torch; model = torch.load('model_best.pth.tar', weights_only=False); exit(0) if (model['best_acc1']>0.4 and model['best_acc1']<0.49) else exit(1)"
 
       - name: Store CIFAR10 test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cifar10-gpu-reports
           path: runs/cifar10/test-reports

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -95,7 +95,9 @@ jobs:
       - name: Cache MNIST dataset
         uses: actions/cache@v5
         with:
-          path: runs/mnist/data
+          path: |
+            runs/mnist/data
+            !runs/mnist/data/MNIST/raw/*.gz
           key: mnist-dataset
 
       - name: Run MNIST integration test (CUDA)


### PR DESCRIPTION
## Types of changes

Recent GPU builds have been flaky due to [pytorch/vision#9536.](https://github.com/pytorch/vision/issues/9536) as discussed in [a recent attempt to solve the flakiness](https://github.com/meta-pytorch/opacus/pull/835#issuecomment-4926626410).

This PR caches the downloaded data so that future builds load from the cache instead of the slower CDN. It removes the compressed download file since it is not needed for future runs. The loader checks the directories for correctness and ignores the .gz files.

The cache step needs to be run before the download occurs.

It would help to rerun the ci_gpu.yml build after it passes once to verify these changes take effect before merging if possible.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

Recent slowness from the cifar10 CDN is causing some builds to fail or run for > 1 hour.

## How Has This Been Tested (if it applies)

The PR is tested during the builds. Locally I verified the .gz files are in the correct location. I also verified the idioms in the github actions to be correct. The versions were checked for python 3.9 compatibility.

## Checklist


- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
