### PR TITLE
Patch neg eps bug and add test for each accountant

### DIFF
--- a/opacus/accountants/analysis/gdp.py
+++ b/opacus/accountants/analysis/gdp.py
@@ -94,6 +94,9 @@ def eps_from_mu(*, mu: float, delta: float) -> float:
         """Reversely solve dual by matching delta."""
         return delta_eps_mu(eps=x, mu=mu) - delta
 
+    if f(0) <= 0:
+        return 0.0
+
     return optimize.root_scalar(f, bracket=[0, 500], method="brentq").root
 
 

--- a/opacus/accountants/prv.py
+++ b/opacus/accountants/prv.py
@@ -103,7 +103,7 @@ class PRVAccountant(IAccountant):
         # this discrete PRV can be used to directly estimate and bound epsilon
         _, _, eps_upper = dprv.compute_epsilon(delta, delta_error, eps_error)
         # return upper bound as we want guarantee, not just estimate
-        return eps_upper
+        return max(eps_upper, 0.0)
 
     def _get_dprv(self, eps_error, delta_error):
         # convert history to privacy loss random variables (prvs). Opacus currently

--- a/opacus/accountants/rdp.py
+++ b/opacus/accountants/rdp.py
@@ -65,7 +65,7 @@ class RDPAccountant(IAccountant):
         eps, best_alpha = privacy_analysis.get_privacy_spent(
             orders=alphas, rdp=rdp, delta=delta
         )
-        return float(eps), float(best_alpha)
+        return float(max(eps, 0.0)), float(best_alpha)
 
     def get_epsilon(
         self,

--- a/opacus/tests/accountants_test.py
+++ b/opacus/tests/accountants_test.py
@@ -129,6 +129,18 @@ class AccountingTest(unittest.TestCase):
         epsilon = accountant.get_epsilon(delta=1e-5)
         self.assertAlmostEqual(epsilon, 6.777395712150674)
 
+    def test_epsilon_non_negative_at_large_delta(self) -> None:
+        # Fix for: https://github.com/meta-pytorch/opacus/issues/585
+        # when delta >= delta(eps=0) eps must be clamped to 0 to avoid
+        #   negatives(rdp, prv) or failing(gdp)
+        for accountant, delta in (
+            (PRVAccountant(), 0.08),
+            (RDPAccountant(), 0.2),
+            (GaussianAccountant(), 0.08),
+        ):
+            accountant.step(noise_multiplier=1.2, sample_rate=0.2)
+            self.assertGreaterEqual(accountant.get_epsilon(delta=delta), 0.0)
+
     def test_len_counts_optimization_steps(self) -> None:
         noise_multiplier = 1.5
         sample_rate = 0.04


### PR DESCRIPTION
## Types of changes

Minimal clamping change to avoid returning negative epsilon values(rdp, prv) or failing(gdp)


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

Issue was raised [585](https://github.com/meta-pytorch/opacus/issues/585) for prv. 
Adds a clamp to avoid negative epsilons for rdp and prv. rdp had a similar negative epsilon issue. 
gdp failed because brentq did not find a sign change between [0, 500].

## How Has This Been Tested (if it applies)

I added a test that previously failed for the three accountants.

## Checklist


- [ ] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
