### PR TITLE
Diagnose inconsistent per-sample batch dimensions before flat clipping

### DIFF
--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -435,14 +435,28 @@ class DPOptimizer(Optimizer):
         Stores clipped and aggregated gradients into `p.summed_grad```
         """
 
-        if len(self.grad_samples[0]) == 0:
-            # Empty batch
-            per_sample_clip_factor = torch.zeros(
-                (0,), device=self.grad_samples[0].device
+        grad_samples = self.grad_samples
+        batch_sizes = [len(g) for g in grad_samples]
+        if len(set(batch_sizes)) > 1:
+            details = ", ".join(
+                f"parameter {i} (shape {tuple(p.shape)}): {n}"
+                for i, (p, n) in enumerate(zip(self.params, batch_sizes))
             )
+            raise ValueError(
+                "Per-sample gradients have inconsistent batch dimensions: "
+                f"{details}. All optimized parameters must have one gradient per "
+                "example. This can occur when inputs such as position_ids are "
+                "broadcast across the batch. If so, expand those inputs to the "
+                "actual batch size before the forward pass; repeating gradients after "
+                "backward does not recover per-example contributions."
+            )
+
+        if len(grad_samples[0]) == 0:
+            # Empty batch
+            per_sample_clip_factor = torch.zeros((0,), device=grad_samples[0].device)
         else:
             per_param_norms = [
-                g.reshape(len(g), -1).norm(2, dim=-1) for g in self.grad_samples
+                g.reshape(len(g), -1).norm(2, dim=-1) for g in grad_samples
             ]
 
             if per_param_norms:
@@ -454,6 +468,8 @@ class DPOptimizer(Optimizer):
                 self.max_grad_norm / (per_sample_norms + 1e-6)
             ).clamp(max=1.0)
 
+        # Release concatenated accumulated gradients before processing parameters.
+        del grad_samples
         for p in self.params:
             _check_processed_flag(p.grad_sample)
             grad_sample = self._get_flat_grad_sample(p)

--- a/opacus/tests/broadcast_grad_sample_test.py
+++ b/opacus/tests/broadcast_grad_sample_test.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import unittest
+
+import torch
+from opacus.grad_sample import GradSampleModule
+from opacus.optimizers import DPOptimizer
+from torch import nn
+
+
+class PositionModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.projection = nn.Linear(3, 3)
+        self.position = nn.Embedding(4, 3)
+
+    def forward(self, x, expand=False):
+        ids = torch.arange(x.shape[1], device=x.device).unsqueeze(0)
+        if expand:
+            ids = ids.expand(x.shape[0], -1)
+        return self.projection(x) + self.position(ids)
+
+
+class BroadcastGradSampleTest(unittest.TestCase):
+    def test_accumulated_and_empty_gradients(self):
+        for sizes in ((0,), (2, 3)):
+            with self.subTest(sizes=sizes):
+                params = [nn.Parameter(torch.ones(2)) for _ in range(2)]
+                optimizer = DPOptimizer(
+                    torch.optim.SGD(params, lr=0.1),
+                    noise_multiplier=0,
+                    max_grad_norm=1,
+                    expected_batch_size=5,
+                    loss_reduction="sum",
+                )
+                for p in params:
+                    p.grad_sample = [torch.ones(size, 2) for size in sizes]
+                optimizer.step()
+                # Each sample has four unit gradient coordinates across two parameters.
+                expected = torch.ones(2) - 0.1 * sum(sizes) / (2 + 1e-6)
+                for p in params:
+                    torch.testing.assert_close(p, expected)
+
+    def test_broadcast_fails_before_update(self):
+        model = GradSampleModule(PositionModel(), loss_reduction="sum")
+        optimizer = DPOptimizer(
+            torch.optim.SGD(model.parameters(), lr=0.1),
+            noise_multiplier=0,
+            max_grad_norm=1,
+            expected_batch_size=4,
+            loss_reduction="sum",
+        )
+        before = [p.detach().clone() for p in model.parameters()]
+        model(torch.randn(4, 4, 3)).square().sum().backward()
+        self.assertEqual(model._module.position.weight.grad_sample.shape[0], 1)
+        with self.assertRaisesRegex(
+            ValueError, "inconsistent batch dimensions.*position_ids"
+        ):
+            optimizer.step()
+        for p, original in zip(model.parameters(), before):
+            torch.testing.assert_close(p, original)
+            self.assertIsNone(p.summed_grad)
+
+    def test_expanded_inputs_match_individual_gradients(self):
+        for reduction in ("sum", "mean"):
+            with self.subTest(reduction=reduction):
+                torch.manual_seed(841)
+                reference = PositionModel()
+                model = GradSampleModule(
+                    copy.deepcopy(reference), loss_reduction=reduction
+                )
+                x = torch.randn(4, 4, 3)
+                individual = []
+                for sample in x:
+                    reference.zero_grad()
+                    reference(sample.unsqueeze(0)).square().sum().backward()
+                    individual.append([p.grad.clone() for p in reference.parameters()])
+                loss = model(x, expand=True).square().sum()
+                if reduction == "mean":
+                    loss = loss / len(x)
+                loss.backward()
+                for i, p in enumerate(model.parameters()):
+                    expected = torch.stack([g[i] for g in individual])
+                    torch.testing.assert_close(p.grad_sample, expected)
+                self.assertFalse(torch.allclose(individual[0][-1], individual[1][-1]))
+                optimizer = DPOptimizer(
+                    torch.optim.SGD(model.parameters(), lr=0.1),
+                    noise_multiplier=0,
+                    max_grad_norm=1,
+                    expected_batch_size=len(x),
+                    loss_reduction=reduction,
+                )
+                norms = torch.stack(
+                    [
+                        torch.cat([g.flatten() for g in sample]).norm()
+                        for sample in individual
+                    ]
+                )
+                factors = (1 / (norms + 1e-6)).clamp(max=1)
+                before = [p.detach().clone() for p in model.parameters()]
+                optimizer.step()
+                for i, p in enumerate(model.parameters()):
+                    clipped = sum(
+                        f * sample[i] for f, sample in zip(factors, individual)
+                    )
+                    if reduction == "mean":
+                        clipped = clipped / len(x)
+                    torch.testing.assert_close(p, before[i] - 0.1 * clipped)
+
+    def test_empty_mismatch_fails_before_accumulation(self):
+        for sizes in ((0, 1), (1, 0)):
+            with self.subTest(sizes=sizes):
+                params = [nn.Parameter(torch.ones(2)) for _ in sizes]
+                optimizer = DPOptimizer(
+                    torch.optim.SGD(params, lr=0.1),
+                    noise_multiplier=0,
+                    max_grad_norm=1,
+                    expected_batch_size=1,
+                )
+                for p, size in zip(params, sizes):
+                    p.grad_sample = torch.zeros(size, 2)
+                with self.assertRaisesRegex(
+                    ValueError, "inconsistent batch dimensions"
+                ):
+                    optimizer.step()
+                for p in params:
+                    self.assertIsNone(p.summed_grad)


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

When a model broadcasts learned position embeddings from a batch of one, their per-sample gradients can have a different batch dimension from the other parameters. Flat clipping then fails with a generic `torch.stack` error. Related to #841.

Validate batch dimensions before flat clipping and report optimizer parameter indices, shapes, and gradient batch sizes. The error explains that expanding position IDs before forward can prevent this failure. No gradient accumulation or parameter update occurs when this check fails.

This detects inconsistent dimensions; it does not automatically support broadcast inputs or prove independence when dimensions agree. The check applies to `DPOptimizer.clip_and_accumulate`, not every optimizer subclass that overrides clipping.

Broadcasting shares input IDs, not per-example gradients. Backward sums contributions across the broadcast dimension, so repeating the captured gradient cannot reconstruct the original contributions. Automatic recovery is outside this change.

## How Has This Been Tested

A tiny CPU model combines a projection with learned position embeddings, without requiring Transformers or model downloads. Regression tests cover:

- Broadcast inputs fail with the diagnostic before accumulation or an update.
- Expanded inputs match independent single-example gradients under sum and mean reductions.
- Noise-free clipped SGD updates match a manually clipped reference.
- Empty/nonempty gradient mismatches fail in either parameter order.
- Valid empty batches and accumulated gradient lists retain their expected updates.

Replacing the clipping method with its unchanged upstream implementation reproduces the stack error for broadcast inputs and fails both empty-mismatch subcases. The valid-input reference tests pass with both implementations.

Run with `python -m pytest opacus/tests/broadcast_grad_sample_test.py -q`.

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the CONTRIBUTING document and completed the CLA.
- [x] All tests passed, and additional code has been covered with new tests (targeted suites below).

Local validation:

- Final regression, embedding, and privacy-engine tests: 244 passed, 17 skipped (36 subtests).
- BatchMemoryManager tests: 7 passed, 2 skipped, after allowing DataLoader worker processes outside the sandbox.
- Flake8, repository isort command, and git diff whitespace checks passed.
- Black 26.5.1 disagrees with the repository isort requirement of two blank lines after imports. The same Black failure reproduces on the unchanged upstream optimizer file. Preserve upstream import spacing pending maintainer preference.

CUDA coverage and the entire repository suite have not been run locally.
